### PR TITLE
Fix webhook validation

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -79,6 +79,8 @@ if cfg.get('enable_repo', True):
       env={
         'GITLAB_TOKEN': os.getenv('GITLAB_TOKEN'),
         'TF_VAR_ngrok_url': get_ngrok_url(cfg),
+        'TF_VAR_kubechecks_gitlab_hook_secret_key': os.getenv('KUBECHECKS_WEBHOOK_SECRET') if os.getenv('KUBECHECKS_WEBHOOK_SECRET') != None else "",
+
       },
       deps=[
         './localdev/terraform/*.tf',
@@ -102,6 +104,7 @@ if cfg.get('enable_repo', True):
       env={
         'GITHUB_TOKEN': os.getenv('GITHUB_TOKEN'),
         'TF_VAR_ngrok_url': get_ngrok_url(cfg),
+        'TF_VAR_kubechecks_github_hook_secret_key': os.getenv('KUBECHECKS_WEBHOOK_SECRET') if os.getenv('KUBECHECKS_WEBHOOK_SECRET') != None else "",
       },
       deps=[
         './localdev/terraform/*.tf',
@@ -211,8 +214,7 @@ k8s_yaml(helm(
         'deployment.env.KUBECHECKS_ARGOCD_WEBHOOK_URL='+ get_ngrok_url(cfg) +'/argocd/api/webhook',
         'deployment.env.KUBECHECKS_VCS_TYPE=' + cfg.get('vcs-type', 'gitlab'),
         'secrets.env.KUBECHECKS_VCS_TOKEN=' + (os.getenv('GITLAB_TOKEN') if 'gitlab' in cfg.get('vcs-type', 'gitlab') else os.getenv('GITHUB_TOKEN')),
-        'secrets.env.KUBECHECKS_GITHUB_HOOK_SECRET_KEY=' + (os.getenv('KUBECHECKS_HOOK_SECRET') if os.getenv('KUBECHECKS_HOOK_SECRET') != None else ""),
-        'secrets.env.KUBECHECKS_GITLAB_HOOK_SECRET_KEY=' + (os.getenv('KUBECHECKS_HOOK_SECRET') if os.getenv('KUBECHECKS_HOOK_SECRET') != None else ""),
+        'secrets.env.KUBECHECKS_WEBHOOK_SECRET=' + (os.getenv('KUBECHECKS_WEBHOOK_SECRET') if os.getenv('KUBECHECKS_WEBHOOK_SECRET') != None else ""),
         'secrets.env.KUBECHECKS_OPENAI_API_TOKEN=' + (os.getenv('OPENAI_API_TOKEN') if os.getenv('OPENAI_API_TOKEN') != None else ""),],
 ))
 

--- a/localdev/terraform/github/github.tf
+++ b/localdev/terraform/github/github.tf
@@ -42,7 +42,7 @@ resource "github_repository_webhook" "kubechecks" {
   configuration {
     url          = "${var.ngrok_url}/${var.kubecheck_webhook_prefix}/github/project"
     content_type = "json"
-    secret       = var.kubechecks_github_hook_secret_key
+    secret       = var.kubechecks_github_hook_secret_key != "" ? var.kubechecks_github_hook_secret_key : null
     insecure_ssl = false
   }
 

--- a/localdev/terraform/gitlab/gitlab.tf
+++ b/localdev/terraform/gitlab/gitlab.tf
@@ -12,7 +12,7 @@ resource "gitlab_project_hook" "kubechecks_localdev_url" {
   merge_requests_events = true
   push_events           = false
   note_events           = false
-  token                 = var.kubechecks_gitlab_hook_secret_key
+  token                 = var.kubechecks_gitlab_hook_secret_key != "" ? var.kubechecks_gitlab_hook_secret_key : null
 }
 
 resource "local_file" "gitlab_project" {

--- a/pkg/vcs_clients/client.go
+++ b/pkg/vcs_clients/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/labstack/echo/v4"
 	"github.com/zapier/kubechecks/pkg/repo"
 )
 
@@ -54,8 +53,8 @@ type Client interface {
 	PostMessage(context.Context, string, int, string) *Message
 	// Update message with new content
 	UpdateMessage(context.Context, *Message, string) error
-	// Validate webhook secret (if applicable)
-	VerifyHook(string, echo.Context) error
+	// Validate webhook secret and return the body; must be called even if no secret
+	VerifyHook(*http.Request, string) ([]byte, error)
 	// Parse webook payload for valid events
 	ParseHook(*http.Request, []byte) (interface{}, error)
 	// Handle valid events


### PR DESCRIPTION
This PR fixes both production and local development webhook secrets, as well as standardises the environment variable to configure this (such that it's platform agnostic). The API for the Client has changed in a breaking manner, but since we haven't released I doubt this will be a problem.