### PR TITLE
Add in ingress class

### DIFF
--- a/charts/kubechecks/templates/ingress.yaml
+++ b/charts/kubechecks/templates/ingress.yaml
@@ -14,6 +14,9 @@ metadata:
 {{ toYaml .Values.ingress.labels | indent 4 }}
 {{- end }}
 spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end}}
   rules:
   {{- range $host, $paths := .Values.ingress.hosts }}
   - host: {{ $host }}

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -94,7 +94,8 @@ service:
   name: http
 
 ingress:
-  create: true
+  create: false
+  className: ""
   # annotations:
   #   kubernetes.io/ingress.class: nginx
   #   # See https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html#supported-annotations


### PR DESCRIPTION
Previously, the chart didn't support specifying the ingress class outside of annotations on the Ingress itself. As this is a deprecated feature (https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation), this PR adds support for specifying the class.