### PR TITLE
Handle errors from Git Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ localdev/terraform/gitlab/project.url
 *.tgz
 *.DS_Store
 kubechecks
+localdev/terraform/github/project.url

--- a/Earthfile
+++ b/Earthfile
@@ -14,10 +14,10 @@ ci-helm:
     BUILD +test-helm
 
 build:
-    BUILD +build-docker
+    BUILD --platform=linux/amd64 --platform=linux/arm64 +build-docker
 
 release:
-    BUILD +release-docker
+    BUILD --platform=linux/amd64 --platform=linux/arm64 +release-docker
     BUILD +release-helm
 
 go-deps:

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -231,7 +231,7 @@ func InitializeGitSettings(user string, email string) error {
 		return err
 	}
 
-	cmd = exec.Command("echo", fmt.Sprintf("https://%s:%s@gitlab.com", email, viper.GetString("vcs-token")))
+	cmd = exec.Command("echo", fmt.Sprintf("https://%s:%s@%s.com", user, viper.GetString("vcs-token"), viper.GetString("vcs-type")))
 	homedir, err := os.UserHomeDir()
 	if err != nil {
 		if err != nil {
@@ -258,5 +258,9 @@ func InitializeGitSettings(user string, email string) error {
 		log.Error().Err(err).Msg("unable to set git credential usage")
 		return err
 	}
+	log.Debug().Msg("git credentials set")
+	cmd = exec.Command("git", "config", "--list")
+	err = cmd.Run()
+
 	return nil
 }

--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -259,8 +259,6 @@ func InitializeGitSettings(user string, email string) error {
 		return err
 	}
 	log.Debug().Msg("git credentials set")
-	cmd = exec.Command("git", "config", "--list")
-	err = cmd.Run()
 
 	return nil
 }

--- a/pkg/server/hook_handler.go
+++ b/pkg/server/hook_handler.go
@@ -100,7 +100,7 @@ func (h *VCSHookHandler) groupHandler(c echo.Context) error {
 		switch err {
 		case vcs_clients.ErrInvalidType:
 			log.Debug().Msg("Ignoring event, not a merge request")
-			return c.String(http.StatusAccepted, "Skipped")
+			return c.String(http.StatusOK, "Skipped")
 		default:
 			// TODO: do something ELSE with the error
 			log.Error().Err(err).Msg("Failed to create a repository locally")
@@ -110,7 +110,7 @@ func (h *VCSHookHandler) groupHandler(c echo.Context) error {
 
 	// We now have a generic repo with all the info we need to start processing an event. Hand off to the event processor
 	go h.processCheckEvent(ctx, repo)
-	return nil
+	return c.String(http.StatusAccepted, "Accepted")
 }
 
 // Takes a constructed Repo, and attempts to run the Kubechecks processing suite against it.

--- a/pkg/server/hook_handler.go
+++ b/pkg/server/hook_handler.go
@@ -143,6 +143,7 @@ func (h *VCSHookHandler) processCheckEvent(ctx context.Context, repo *repo.Repo)
 		log.Error().Err(err).Msg("unable to create temp dir")
 	}
 	defer cEvent.Cleanup(ctx)
+
 	err = cEvent.InitializeGit(ctx)
 	if err != nil {
 		telemetry.SetError(span, err, "Initialize Git")
@@ -153,6 +154,7 @@ func (h *VCSHookHandler) processCheckEvent(ctx context.Context, repo *repo.Repo)
 	err = cEvent.CloneRepoLocal(ctx)
 	if err != nil {
 		// TODO: Cancel event if gitlab etc
+		telemetry.SetError(span, err, "Clone Repo Local")
 		log.Error().Err(err).Msg("unable to clone repo locally")
 		return
 	}

--- a/pkg/server/hook_handler.go
+++ b/pkg/server/hook_handler.go
@@ -143,11 +143,17 @@ func (h *VCSHookHandler) processCheckEvent(ctx context.Context, repo *repo.Repo)
 		log.Error().Err(err).Msg("unable to create temp dir")
 	}
 	defer cEvent.Cleanup(ctx)
-	cEvent.InitializeGit(ctx)
+	err = cEvent.InitializeGit(ctx)
+	if err != nil {
+		telemetry.SetError(span, err, "Initialize Git")
+		log.Error().Err(err).Msg("unable to initialize git")
+		return
+	}
 	// Clone the repo's BaseRef (main etc) locally into the temp dir we just made
 	err = cEvent.CloneRepoLocal(ctx)
 	if err != nil {
 		// TODO: Cancel event if gitlab etc
+		log.Error().Err(err).Msg("unable to clone repo locally")
 		return
 	}
 

--- a/pkg/vcs_clients/client.go
+++ b/pkg/vcs_clients/client.go
@@ -49,7 +49,7 @@ func (s CommitState) StateToDesc() string {
 }
 
 // Sentinel errors for use in client implementations
-var ErrInvalidType = errors.New("Invalid event type")
+var ErrInvalidType = errors.New("invalid event type")
 
 // Clients need to implement this interface to allow CheckEvents to talk to their respective PR etc
 type Client interface {


### PR DESCRIPTION
Previously, when building the git credentials string (`$user:$token@$platform.com`), we were doing it wrong (`$email:$token@gitlab.com`). This PR fixes it, and also enables cross compilation for different architectures (x86 and ARM)