### PR TITLE
fix: panic in gitlab client when setting commit status

### DIFF
--- a/localdev/kubechecks/values.yaml
+++ b/localdev/kubechecks/values.yaml
@@ -8,11 +8,11 @@ deployment:
     KUBECHECKS_WEBHOOK_URL_PREFIX: 'kubechecks'
     KUBECHECKS_ARGOCD_API_PATH_PREFIX : '/argocd'
     KUBECHECKS_NAMESPACE: 'kubechecks'
-    KUBECHECKS_FALLBACK_K8S_VERSION: "1.22.0"
+    KUBECHECKS_FALLBACK_K8S_VERSION: "1.25.0"
     KUBECHECKS_SHOW_DEBUG_INFO: "true"
     KUBECHECKS_OTEL_COLLECTOR_PORT: "4317"
     KUBECHECKS_OTEL_ENABLED: "false"
-    KUBECHECKS_LABEL_FILTER: "test" # On your PR/MR, prefix this with "kubechecks:"
+    # KUBECHECKS_LABEL_FILTER: "test" # On your PR/MR, prefix this with "kubechecks:"
 
   image:
     repository: ""

--- a/localdev/terraform/gitlab/gitlab.tf
+++ b/localdev/terraform/gitlab/gitlab.tf
@@ -1,6 +1,8 @@
 resource "gitlab_project" "kubechecks_test_project" {
   name             = local.random_pet
   visibility_level = "public"
+
+  only_allow_merge_if_pipeline_succeeds = true
 }
 
 # Add a hook to the project

--- a/pkg/gitlab_client/pipeline.go
+++ b/pkg/gitlab_client/pipeline.go
@@ -1,6 +1,8 @@
 package gitlab_client
 
 import (
+
+	"github.com/rs/zerolog/log"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -9,6 +11,7 @@ func (c *Client) GetPipelinesForCommit(projectName string, commitSHA string) ([]
 		SHA: gitlab.String(commitSHA),
 	})
 	if err != nil {
+		log.Error().Err(err).Msg("gitlab client: could not get pipelines for commit")
 		return pipelines, err
 	}
 


### PR DESCRIPTION
Fixes the following panic, that could happen if the API does not return a pipeline status data.
This change also adds some err logging to API calls.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2993b25]

goroutine 90508 [running]:
github.com/zapier/kubechecks/pkg/gitlab_client.(*Client).CommitStatus(0xc0001206e0, {0x3997eb0?, 0xc000d14d50?}, 0xc0005ec380, 0x3)
	/src/pkg/gitlab_client/status.go:12 +0x85
github.com/zapier/kubechecks/pkg/events.(*CheckEvent).CommitStatus(0xc0008783c0, {0x3997eb0, 0xc000d14d50}, 0xc0014c63a0?)
	/src/pkg/events/check.go:270 +0xf1
github.com/zapier/kubechecks/pkg/events.(*CheckEvent).ProcessApps(0xc0008783c0, {0x3997eb0, 0xc000715080})
	/src/pkg/events/check.go:261 +0xc05
github.com/zapier/kubechecks/pkg/server.(*VCSHookHandler).processCheckEvent(0xc00147ae80, {0x3997e40, 0xc00005e030}, 0xc0005ec380)
	/src/pkg/server/hook_handler.go:186 +0xcb6
created by github.com/zapier/kubechecks/pkg/server.(*VCSHookHandler).groupHandler
	/src/pkg/server/hook_handler.go:112 +0x358
```