### PR TITLE
Add exp backoff retry when getting Gitlab Pipeline Status

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,7 +76,7 @@ require k8s.io/apiserver v0.24.2 // indirect
 require go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.31.0 // indirect
 
 require (
-	github.com/cenkalti/backoff/v4 v4.2.0
+	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creasty/defaults v1.7.0
 	github.com/go-logr/zerologr v1.2.3
 	github.com/google/go-github v17.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -302,10 +302,13 @@ github.com/caarlos0/ctrlc v1.0.0/go.mod h1:CdXpj4rmq0q/1Eb44M9zi2nKB0QraNKuRGYGr
 github.com/campoy/unique v0.0.0-20180121183637-88950e537e7e/go.mod h1:9IOqJGCPMSc6E5ydlp5NIonxObaeu/Iub/X03EKPVYo=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e/go.mod h1:oDpT4efm8tSYHXV5tHSdRvBet/b/QzxZ+XyyPehvm3A=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
 github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=

--- a/pkg/gitlab_client/status.go
+++ b/pkg/gitlab_client/status.go
@@ -2,7 +2,10 @@ package gitlab_client
 
 import (
 	"context"
+	"errors"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog/log"
 	"github.com/xanzy/go-gitlab"
 	"github.com/zapier/kubechecks/pkg/repo"
@@ -11,6 +14,15 @@ import (
 
 const GitlabCommitStatusContext = "kubechecks"
 
+var expBackOff *backoff.ExponentialBackOff
+var nilPipelineStatus = errors.New("nil pipeline status")
+
+func init() {
+	expBackOff = backoff.NewExponentialBackOff()
+	expBackOff.MaxInterval = 10 * time.Second
+	expBackOff.MaxElapsedTime = 30 * time.Second
+}
+
 func (c *Client) CommitStatus(ctx context.Context, repo *repo.Repo, state vcs_clients.CommitState) error {
 	status := &gitlab.SetCommitStatusOptions{
 		Name:        gitlab.String(GitlabCommitStatusContext),
@@ -18,15 +30,28 @@ func (c *Client) CommitStatus(ctx context.Context, repo *repo.Repo, state vcs_cl
 		Description: gitlab.String(state.StateToDesc()),
 		State:       convertState(state),
 	}
-	// get pipelineStatus so we can attach new status to existing pipeline (if it exists)
-	pipelineStatus := c.GetLastPipelinesForCommit(repo.OwnerName, repo.SHA)
+	// Get pipelineStatus so we can attach new status to existing pipeline. We
+	// retry a few times to avoid creating a duplicate external pipeline status if
+	// another service is also setting it.
+	var pipelineStatus *gitlab.PipelineInfo
+	getStatusFn := func() error {
+		pipelineStatus = c.GetLastPipelinesForCommit(repo.OwnerName, repo.SHA)
+		if pipelineStatus == nil {
+			return nilPipelineStatus
+		}
+		return nil
+	}
+	err := backoff.Retry(getStatusFn, expBackOff)
+	if err != nil {
+		log.Warn().Msg("could not retrieve pipeline status after multiple attempts")
+	}
 	if pipelineStatus != nil {
 		log.Trace().Int("pipeline_id", pipelineStatus.ID).Msg("pipeline status")
 		status.PipelineID = &pipelineStatus.ID
 	}
 
 	log.Debug().Str("project", repo.OwnerName).Str("commit_sha", repo.SHA).Msg("gitlab client: updating commit status")
-	_, err := c.setCommitStatus(repo.OwnerName, repo.SHA, status)
+	_, err = c.setCommitStatus(repo.OwnerName, repo.SHA, status)
 	if err != nil {
 		log.Error().Err(err).Str("project", repo.OwnerName).Msg("gitlab client: could not set commit status")
 		return err

--- a/pkg/gitlab_client/status.go
+++ b/pkg/gitlab_client/status.go
@@ -14,7 +14,7 @@ import (
 
 const GitlabCommitStatusContext = "kubechecks"
 
-var nilPipelineStatus = errors.New("nil pipeline status")
+var errNoPipelineStatus = errors.New("nil pipeline status")
 
 func (c *Client) CommitStatus(ctx context.Context, repo *repo.Repo, state vcs_clients.CommitState) error {
 	status := &gitlab.SetCommitStatusOptions{
@@ -31,7 +31,7 @@ func (c *Client) CommitStatus(ctx context.Context, repo *repo.Repo, state vcs_cl
 		log.Debug().Msg("getting pipeline status")
 		pipelineStatus = c.GetLastPipelinesForCommit(repo.OwnerName, repo.SHA)
 		if pipelineStatus == nil {
-			return nilPipelineStatus
+			return errNoPipelineStatus
 		}
 		return nil
 	}


### PR DESCRIPTION
If multiple external apps update a Gitlab pipeline status for an MR at the same time, Gitlab will often create duplicates instead of merging. This change makes kubechecks retry getting an existing pipeline status a few times (if no pipeline status is found) before adding it's own. 