### PR TITLE
Allow common label setting for Helm resources

### DIFF
--- a/charts/kubechecks/templates/_helpers.tpl
+++ b/charts/kubechecks/templates/_helpers.tpl
@@ -40,6 +40,12 @@ helm.sh/chart: {{ include "kubechecks.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels }}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end }}
+
+{{/*
 {{- end }}
 
 {{/*

--- a/charts/kubechecks/tests/basic_deployment_test.yaml
+++ b/charts/kubechecks/tests/basic_deployment_test.yaml
@@ -109,4 +109,13 @@ tests:
             successThreshold: 1
             timeoutSeconds: 5
 
+  - it: should allow configuration of labels
+    set:
+      commonLabels:
+        team: "test"
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: "test"
+
 

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -1,3 +1,6 @@
+# Labels to apply to all resources created by this Helm chart
+commonLabels: {}
+
 deployment:
   annotations: {}
     # reloader.stakater.com/auto: "true"


### PR DESCRIPTION
Currently we don't support arbitrary label setting via Helm; this fixes that