### PR TITLE
Apply common labels

### DIFF
--- a/charts/kubechecks/templates/deployment.yaml
+++ b/charts/kubechecks/templates/deployment.yaml
@@ -15,6 +15,9 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.commonLabels }}
+        {{- toYaml .Values.commonLabels | nindent 8 }}
+        {{- end }}
         {{- include "kubechecks.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.deployment.imagePullSecrets }}


### PR DESCRIPTION
We don't carry the labels through to the pods created by the Deployment; this PR fixes that.