### PR TITLE
[Helm chart] `.Values.podSecurityContext` is not used

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.2.1
+version: 0.2.2
 appVersion: "1.0.7"
 type: application
 maintainers:

--- a/charts/kubechecks/templates/deployment.yaml
+++ b/charts/kubechecks/templates/deployment.yaml
@@ -27,7 +27,8 @@ spec:
       {{- if .Values.serviceAccount.enabled}}
       serviceAccountName: {{ include "kubechecks.serviceAccountName" . }}
       {{- end }}
-      securityContext: {{- toYaml .Values.deployment.securityContext | nindent 8 }}
+      securityContext:
+        {{- toYaml .Values.deployment.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.deployment.image }}

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -28,16 +28,18 @@ deployment:
 
   affinity: {}
 
-  podSecurityContext: {}
-  # fsGroup: 2000
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 32123
+    # fsGroup: 32123
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    privileged: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
 
   env:
     # KUBECHECKS_ARGOCD_API_INSECURE: "false"

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -28,18 +28,18 @@ deployment:
 
   affinity: {}
 
-  podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 32123
+  podSecurityContext: {}
+    # runAsNonRoot: true
+    # runAsUser: 32123
     # fsGroup: 32123
 
-  securityContext:
-    allowPrivilegeEscalation: false
-    privileged: false
-    capabilities:
-      drop:
-        - ALL
-    readOnlyRootFilesystem: true
+  securityContext: {}
+    # allowPrivilegeEscalation: false
+    # privileged: false
+    # capabilities:
+    #   drop:
+    #     - ALL
+    # readOnlyRootFilesystem: false
 
   env:
     # KUBECHECKS_ARGOCD_API_INSECURE: "false"


### PR DESCRIPTION
In the Kubechecks Helm chart, the `podSecurityContext` Value is not being used. Instead, the `securityContext` is included both at the pod and container level, which leads to "unsupported field" errors at the pod level. I just changed the deployment template to include the `podSecurityContext`.

I would also suggest providing sane defaults for both, instead of commenting them out in the values.yaml. Of course, feel free to revert this. ;)

Cheers!