### PR TITLE
Add fallback schema location for CustomResourceDefinition Kinds

### DIFF
--- a/pkg/vcs_clients/message.go
+++ b/pkg/vcs_clients/message.go
@@ -16,7 +16,7 @@ const (
 	appFormat = `<details><summary>
 
 ## ArgoCD Application Checks:` + "`%s` %s" +
-			`
+		`
 </summary>
 %s 
 </details>
@@ -79,7 +79,7 @@ func (m *Message) buildComment(ctx context.Context) string {
 	defer span.End()
 
 	var names []string
-	for _, name := range m.Apps {
+	for name := range m.Apps {
 		names = append(names, name)
 	}
 	sort.Strings(names)


### PR DESCRIPTION
Manifests of kind CustomResourceDefinition fail validation. Here's a fix as stated here: https://github.com/yannh/kubeconform/issues/100#issuecomment-1096832969


![screenshot](https://cdn.zappy.app/fc0b0ccc7a6d35eff0c103e43911750d.png)