### PR TITLE
Update OpenAI GPT4 model

### DIFF
--- a/pkg/aisummary/diff_summary.go
+++ b/pkg/aisummary/diff_summary.go
@@ -15,7 +15,7 @@ func (c *OpenAiClient) SummarizeDiff(ctx context.Context, appName string, manife
 	ctx, span := otel.Tracer("Kubechecks").Start(ctx, "SummarizeDiff")
 	defer span.End()
 
-	model := openai.GPT40314
+	model := openai.GPT4
 	if len(diff) < 3500 {
 		model = openai.GPT3Dot5Turbo
 	}


### PR DESCRIPTION
![Img](https://cdn.zappy.app/b57b87a2a890d44a6fbb6114a9ad4d75.png) GPT4-0314 is now legacy. 