### PR TITLE
Support pod annotations in Helm chart

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.3.1
+version: 0.3.2
 appVersion: "1.0.10"
 type: application
 maintainers:

--- a/charts/kubechecks/templates/deployment.yaml
+++ b/charts/kubechecks/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       {{- include "kubechecks.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with .Values.deployment.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
         {{- if .Values.commonLabels }}
         {{- toYaml .Values.commonLabels | nindent 8 }}

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -5,6 +5,8 @@ deployment:
   annotations: {}
     # reloader.stakater.com/auto: "true"
 
+  podAnnotations: {}
+
   args: []
 
   # Default values for kubechecks.


### PR DESCRIPTION
This PR adds the ability to add annotations to the deployment's pod template.

Use cases for this are plenty and `podAnnotations` is a common option in Helm charts. In our case, we need these to select a less restrictive [pod security standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) for the Kubechecks pod, since it needs to run as root.

I have no real preference whether the key should be `.Values.podAnnotations` or `.Values.deployment.podAnnotations`. I just placed it next to the key for deployment annotations.