### PR TITLE
make it easier to test pull request images

### DIFF
--- a/.github/workflows/maintenance.yaml
+++ b/.github/workflows/maintenance.yaml
@@ -1,0 +1,20 @@
+name: Maintenance
+
+# Deleting untagged images requires a Personal Access Token, it cannot
+# be done with a github action built in token. This is a known limitation.
+
+on:
+  schedule:
+    - cron: "0 0 * * SUN"
+  workflow_dispatch:
+
+jobs:
+  delete-untagged-images:
+    name: delete untagged images
+    runs-on: self-hosted
+    steps:
+      - uses: Chizkiyahu/delete-untagged-ghcr-action@v3
+        with:
+          owner_type: org
+          token: ${{ secrets.MAINTENANCE_TOKEN }}
+          untagged_only: true

--- a/.github/workflows/on_pull-request_closed.yaml
+++ b/.github/workflows/on_pull-request_closed.yaml
@@ -1,0 +1,35 @@
+name: PR closed
+
+on:
+  pull_request:
+    types:
+      - closed
+
+env:
+  FS_IMAGE: ghcr.io/${{ github.repository }}
+  FS_TAG: 0.0.0-pr${{ github.event.pull_request.number }}
+
+jobs:
+  remove-temp-image:
+    runs-on: ubuntu-22.04
+
+    # should match env.FS_TAG, in both pr-open.yaml and pr-close.yaml
+    concurrency: pr-${{ github.event.pull_request.number }}
+
+    permissions:
+      packages: write
+      pull-requests: write
+
+    steps:
+      - name: Delete all images without tags
+        uses: bots-house/ghcr-delete-image-action@v1.1.0
+        with:
+          owner: zapier
+          name: kubechecks
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.FS_TAG }}
+
+      - uses: mshick/add-pr-comment@v2
+        with:
+          message: |
+            Temporary image deleted.

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -9,10 +9,14 @@ on:
       - '!COPYING.LGPL-3'
       - '!.gitattributes'
       - '!.gitignore'
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 env:
-  FS_IMAGE: ttl.sh/${{ github.repository }}/pr-${{ github.event.pull_request.number }}/${{ github.event.pull_request.head.sha }}
-  FS_TAG: 24h
+  FS_IMAGE: ghcr.io/${{ github.repository }}
+  FS_TAG: 0.0.0-pr${{ github.event.pull_request.number }}
 
 # TODO: Move this to repo config
 jobs:
@@ -69,4 +73,4 @@ jobs:
       - uses: mshick/add-pr-comment@v2
         with:
           message: |
-            Temporary image available at `${{ env.FS_IMAGE }}:${{ env.FS_TAG }}` for 24 hours. If you need another built, close and reopen the PR.
+            Temporary image available at `${{ env.FS_IMAGE }}:${{ env.FS_TAG }}`.

--- a/.github/workflows/on_push_to_main.yaml
+++ b/.github/workflows/on_push_to_main.yaml
@@ -3,6 +3,9 @@ on:
     branches:
       - main
 
+env:
+  FS_IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
   release-docker:
     runs-on: ubuntu-22.04
@@ -36,6 +39,7 @@ jobs:
       - name: extract sha
         run: |
           echo "GIT_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "GIT_TAG=$(git describe)" >> $GITHUB_ENV
 
       - name: login to registry
         uses: docker/login-action@v1
@@ -52,9 +56,9 @@ jobs:
             +docker-dev \
               --HELM_VERSION=${{ env.HELM_TOOL_VERSION }} \
               --KUSTOMIZE_VERSION=${{ env.KUSTOMIZE_TOOL_VERSION }} \
-              --GIT_TAG=main-${{ matrix.platform.suffix }} \
+              --GIT_TAG=${{ env.GIT_TAG }} \
               --GIT_COMMIT=${{ env.GIT_COMMIT }} \
-              --CI_REGISTRY_IMAGE=ghcr.io/${{ github.repository_owner }}/kubechecks
+              --CI_REGISTRY_IMAGE=${{ env.FS_IMAGE }}
 
   release-multiarch:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Build an image per PR, keep it up to date, and delete it when the PR closes.

This does 4 things:
- on PR create/update, build and push an image called `0.0.0-pr##` (named this way b/c ghcr requires semver compatible tags)
- on PR close, delete the `0.0.0-pr##` tag
- once a week, delete untagged images
- when publishing to main, build and push an image tagged via `git describe` (something like `$LAST_TAG-$NUMCOMMITS-g$HASH`)