### PR TITLE
This can't be set if we call 'StdoutPipe' or 'CombinedOutput' later

### DIFF
--- a/pkg/repo/repo.go
+++ b/pkg/repo/repo.go
@@ -226,8 +226,6 @@ func execCommand(name string, args ...string) *exec.Cmd {
 
 	log.Debug().Strs("args", argsToLog).Msg("building command")
 	cmd := exec.Command(name, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
 	return cmd
 }
 


### PR DESCRIPTION
This should resolve errors like:
```
2:42AM ERR unable to clone repository, error="exec: Stdout already set"
```