### PR TITLE
re-run apps when they're updated

### DIFF
--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -171,6 +171,9 @@ func GetDiff(ctx context.Context, manifests []string, app argoappv1.Application,
 				}
 			case diffRes.Modified:
 				modified++
+				if app, ok := isApp(item, diffRes.PredictedLive); ok {
+					addApp(app)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This supports scenarios where, for example, you add a new helm values file to the argo application along w/ the actual changes in the same PR.