### PR TITLE
ensure that head refs are dealt with properly

### DIFF
--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -130,11 +130,15 @@ func canonicalize(cloneURL string) (pkg.RepoURL, error) {
 	return parsed, nil
 }
 
-func generateRepoKey(cloneURL, branchName string) string {
-	return fmt.Sprintf("%s|||%s", cloneURL, branchName)
+func generateRepoKey(cloneURL pkg.RepoURL, branchName string) string {
+	return fmt.Sprintf("%s|||%s", cloneURL.CloneURL(""), branchName)
 }
 
-func (ce *CheckEvent) getRepo(ctx context.Context, cloneURL, branchName string) (*git.Repo, error) {
+type hasUsername interface {
+	Username() string
+}
+
+func (ce *CheckEvent) getRepo(ctx context.Context, vcsClient hasUsername, cloneURL, branchName string) (*git.Repo, error) {
 	var (
 		err  error
 		repo *git.Repo
@@ -147,10 +151,13 @@ func (ce *CheckEvent) getRepo(ctx context.Context, cloneURL, branchName string) 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse clone url")
 	}
-	cloneURL = parsed.CloneURL(ce.ctr.VcsClient.Username())
+	cloneURL = parsed.CloneURL(vcsClient.Username())
 
 	branchName = strings.TrimSpace(branchName)
-	reposKey := generateRepoKey(cloneURL, branchName)
+	if branchName == "" {
+		branchName = "HEAD"
+	}
+	reposKey := generateRepoKey(parsed, branchName)
 
 	if repo, ok := ce.clonedRepos[reposKey]; ok {
 		return repo, nil
@@ -171,12 +178,12 @@ func (ce *CheckEvent) getRepo(ctx context.Context, cloneURL, branchName string) 
 		}
 
 		repo.BranchName = remoteHeadBranchName
-		ce.clonedRepos[generateRepoKey(cloneURL, remoteHeadBranchName)] = repo
+		ce.clonedRepos[generateRepoKey(parsed, remoteHeadBranchName)] = repo
 	}
 
 	// if we don't have a 'HEAD' saved for the cloned repo, figure out which branch HEAD points to,
 	// and if it's the one we just cloned, store a copy of it as 'HEAD' for usage later
-	headKey := generateRepoKey(cloneURL, "HEAD")
+	headKey := generateRepoKey(parsed, "HEAD")
 	if _, ok := ce.clonedRepos[headKey]; !ok {
 		remoteHeadBranchName, err := repo.GetRemoteHead()
 		if err != nil {
@@ -195,7 +202,7 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 	defer span.End()
 
 	// Clone the repo's BaseRef (main etc) locally into the temp dir we just made
-	repo, err := ce.getRepo(ctx, ce.pullRequest.CloneURL, ce.pullRequest.BaseRef)
+	repo, err := ce.getRepo(ctx, ce.ctr.VcsClient, ce.pullRequest.CloneURL, ce.pullRequest.BaseRef)
 	if err != nil {
 		return errors.Wrap(err, "failed to clone repo")
 	}
@@ -361,7 +368,7 @@ func (ce *CheckEvent) processApp(ctx context.Context, app v1alpha1.Application) 
 	// Build a new section for this app in the parent comment
 	ce.vcsNote.AddNewApp(ctx, appName)
 
-	repo, err := ce.getRepo(ctx, appRepoUrl, appSrc.TargetRevision)
+	repo, err := ce.getRepo(ctx, ce.ctr.VcsClient, appRepoUrl, appSrc.TargetRevision)
 	if err != nil {
 		logger.Error().Err(err).Msg("Unable to clone repository")
 		ce.vcsNote.AddToAppMessage(ctx, appName, msg.Result{

--- a/pkg/events/check_test.go
+++ b/pkg/events/check_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/zapier/kubechecks/pkg/config"
 	"github.com/zapier/kubechecks/pkg/git"
 )
 
@@ -59,17 +60,10 @@ func (m mockVcsClient) Username() string {
 	return "username"
 }
 
-type mockRepoManager struct {
-	err error
-}
-
-func (m mockRepoManager) Clone(ctx context.Context, cloneURL, branchName string) (*git.Repo, error) {
-	return &git.Repo{CloneURL: cloneURL, BranchName: branchName}, m.err
-}
-
 func TestCheckEventGetRepo(t *testing.T) {
 	cloneURL := "https://github.com/zapier/kubechecks.git"
 	canonical, err := canonicalize(cloneURL)
+	cfg := config.ServerConfig{}
 	require.NoError(t, err)
 
 	ctx := context.TODO()
@@ -77,9 +71,7 @@ func TestCheckEventGetRepo(t *testing.T) {
 	t.Run("empty branch name", func(t *testing.T) {
 		ce := CheckEvent{
 			clonedRepos: make(map[string]*git.Repo),
-			repoManager: mockRepoManager{
-				err: nil,
-			},
+			repoManager: git.NewRepoManager(cfg),
 		}
 
 		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "")
@@ -93,9 +85,7 @@ func TestCheckEventGetRepo(t *testing.T) {
 	t.Run("branch is HEAD", func(t *testing.T) {
 		ce := CheckEvent{
 			clonedRepos: make(map[string]*git.Repo),
-			repoManager: mockRepoManager{
-				err: nil,
-			},
+			repoManager: git.NewRepoManager(cfg),
 		}
 
 		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "HEAD")
@@ -109,9 +99,7 @@ func TestCheckEventGetRepo(t *testing.T) {
 	t.Run("branch is the same as HEAD", func(t *testing.T) {
 		ce := CheckEvent{
 			clonedRepos: make(map[string]*git.Repo),
-			repoManager: mockRepoManager{
-				err: nil,
-			},
+			repoManager: git.NewRepoManager(cfg),
 		}
 
 		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "main")
@@ -125,9 +113,7 @@ func TestCheckEventGetRepo(t *testing.T) {
 	t.Run("branch is not the same as HEAD", func(t *testing.T) {
 		ce := CheckEvent{
 			clonedRepos: make(map[string]*git.Repo),
-			repoManager: mockRepoManager{
-				err: nil,
-			},
+			repoManager: git.NewRepoManager(cfg),
 		}
 
 		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "gh-pages")

--- a/pkg/events/check_test.go
+++ b/pkg/events/check_test.go
@@ -1,9 +1,15 @@
 package events
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/zapier/kubechecks/pkg/git"
 )
 
 // TestCleanupGetManifestsError tests the cleanupGetManifestsError function.
@@ -45,4 +51,89 @@ func TestCleanupGetManifestsError(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockVcsClient struct{}
+
+func (m mockVcsClient) Username() string {
+	return "username"
+}
+
+type mockRepoManager struct {
+	err error
+}
+
+func (m mockRepoManager) Clone(ctx context.Context, cloneURL, branchName string) (*git.Repo, error) {
+	return &git.Repo{CloneURL: cloneURL, BranchName: branchName}, m.err
+}
+
+func TestCheckEventGetRepo(t *testing.T) {
+	cloneURL := "https://github.com/zapier/kubechecks.git"
+	canonical, err := canonicalize(cloneURL)
+	require.NoError(t, err)
+
+	ctx := context.TODO()
+
+	t.Run("empty branch name", func(t *testing.T) {
+		ce := CheckEvent{
+			clonedRepos: make(map[string]*git.Repo),
+			repoManager: mockRepoManager{
+				err: nil,
+			},
+		}
+
+		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "")
+		require.NoError(t, err)
+		assert.Equal(t, "main", repo.BranchName)
+		assert.Len(t, ce.clonedRepos, 2)
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "HEAD"))
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "main"))
+	})
+
+	t.Run("branch is HEAD", func(t *testing.T) {
+		ce := CheckEvent{
+			clonedRepos: make(map[string]*git.Repo),
+			repoManager: mockRepoManager{
+				err: nil,
+			},
+		}
+
+		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "HEAD")
+		require.NoError(t, err)
+		assert.Equal(t, "main", repo.BranchName)
+		assert.Len(t, ce.clonedRepos, 2)
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "HEAD"))
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "main"))
+	})
+
+	t.Run("branch is the same as HEAD", func(t *testing.T) {
+		ce := CheckEvent{
+			clonedRepos: make(map[string]*git.Repo),
+			repoManager: mockRepoManager{
+				err: nil,
+			},
+		}
+
+		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "main")
+		require.NoError(t, err)
+		assert.Equal(t, "main", repo.BranchName)
+		assert.Len(t, ce.clonedRepos, 2)
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "HEAD"))
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "main"))
+	})
+
+	t.Run("branch is not the same as HEAD", func(t *testing.T) {
+		ce := CheckEvent{
+			clonedRepos: make(map[string]*git.Repo),
+			repoManager: mockRepoManager{
+				err: nil,
+			},
+		}
+
+		repo, err := ce.getRepo(ctx, mockVcsClient{}, cloneURL, "gh-pages")
+		require.NoError(t, err)
+		assert.Equal(t, "gh-pages", repo.BranchName)
+		assert.Len(t, ce.clonedRepos, 1)
+		assert.Contains(t, ce.clonedRepos, generateRepoKey(canonical, "gh-pages"))
+	})
 }

--- a/pkg/git/manager.go
+++ b/pkg/git/manager.go
@@ -2,11 +2,9 @@ package git
 
 import (
 	"context"
-	"os"
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
 
 	"github.com/zapier/kubechecks/pkg/config"
@@ -38,20 +36,11 @@ func (rm *RepoManager) Clone(ctx context.Context, cloneUrl, branchName string) (
 	return repo, nil
 }
 
-func wipeDir(dir string) {
-	if err := os.RemoveAll(dir); err != nil {
-		log.Error().
-			Err(err).
-			Str("path", dir).
-			Msg("failed to wipe path")
-	}
-}
-
 func (rm *RepoManager) Cleanup() {
 	rm.lock.Lock()
 	defer rm.lock.Unlock()
 
 	for _, repo := range rm.repos {
-		wipeDir(repo.Directory)
+		repo.Wipe()
 	}
 }

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -63,7 +63,7 @@ func (r *Repo) Clone(ctx context.Context) error {
 	defer span.End()
 
 	args := []string{"clone", r.CloneURL, r.Directory}
-	if r.BranchName != "" && r.BranchName != "HEAD" {
+	if r.BranchName != "HEAD" {
 		args = append(args, "--branch", r.BranchName)
 	}
 
@@ -91,6 +91,19 @@ func printFile(s string, d fs.DirEntry, err error) error {
 		println(s)
 	}
 	return nil
+}
+
+func (r *Repo) GetRemoteHead() (string, error) {
+	cmd := r.execCommand("git", "symbolic-ref", "refs/remotes/origin/HEAD", "--short")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to determine which branch HEAD points to")
+	}
+
+	branchName := strings.TrimSpace(string(out))
+	branchName = strings.TrimPrefix(branchName, "origin/")
+
+	return branchName, nil
 }
 
 func (r *Repo) MergeIntoTarget(ctx context.Context, sha string) error {

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/zapier/kubechecks/pkg"
 	"github.com/zapier/kubechecks/pkg/config"
 	"github.com/zapier/kubechecks/pkg/vcs"
 	"github.com/zapier/kubechecks/telemetry"
@@ -144,6 +145,10 @@ func (r *Repo) execCommand(name string, args ...string) *exec.Cmd {
 		cmd.Dir = r.Directory
 	}
 	return cmd
+}
+
+func (r *Repo) Wipe() {
+	pkg.WipeDir(r.Directory)
 }
 
 func (r *Repo) censorVcsToken(args []string) []string {

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -92,7 +92,7 @@ func TestRepoGetRemoteHead(t *testing.T) {
 	cfg := config.ServerConfig{}
 	ctx := context.TODO()
 
-	repo := New(cfg, "git@github.com:zapier/kubechecks.git", "")
+	repo := New(cfg, "https://github.com/zapier/kubechecks.git", "")
 	err := repo.Clone(ctx)
 	require.NoError(t, err)
 

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -87,3 +87,18 @@ git commit -m "commit three"
 	require.NoError(t, err)
 	assert.Equal(t, []string{"abc.txt", "ghi.txt"}, files)
 }
+
+func TestRepoGetRemoteHead(t *testing.T) {
+	cfg := config.ServerConfig{}
+	ctx := context.TODO()
+
+	repo := New(cfg, "git@github.com:zapier/kubechecks.git", "")
+	err := repo.Clone(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(repo.Wipe)
+
+	branch, err := repo.GetRemoteHead()
+	require.NoError(t, err)
+	assert.Equal(t, "main", branch)
+}


### PR DESCRIPTION
when a repo is cloned, it could be cloned with either a named branch OR `HEAD`. in practice, they could refer to the same branch, and this MR fixes the code so they can be referenced interchangeably, when appropriate.