### PR TITLE
Output a better error message when nothing has changed

### DIFF
--- a/pkg/msg/message.go
+++ b/pkg/msg/message.go
@@ -153,6 +153,7 @@ func (m *Message) BuildComment(ctx context.Context) string {
 	var sb strings.Builder
 	sb.WriteString("# Kubechecks Report\n")
 
+	updateWritten := false
 	for _, appName := range names {
 		if m.isDeleted(appName) {
 			continue
@@ -192,6 +193,12 @@ func (m *Message) BuildComment(ctx context.Context) string {
 		sb.WriteString("</summary>\n\n")
 		sb.WriteString(strings.Join(checkStrings, "\n\n---\n\n"))
 		sb.WriteString("</details>")
+
+		updateWritten = true
+	}
+
+	if !updateWritten {
+		sb.WriteString("No changes")
 	}
 
 	return sb.String()


### PR DESCRIPTION
before:
![image](https://github.com/zapier/kubechecks/assets/669730/22037d5e-3220-467f-bc24-eacb1c5cb130)

after:
![image](https://github.com/zapier/kubechecks/assets/669730/0d562305-f531-4429-96d7-762810280b94)
