### PR TITLE
fix: ignore the 403 returned from argocd when creating new app

### DIFF
--- a/pkg/checks/diff/diff.go
+++ b/pkg/checks/diff/diff.go
@@ -220,14 +220,14 @@ func getResources(ctx context.Context, request checks.Request) ([]*argoappv1.Res
 		ApplicationName: &request.App.Name,
 	})
 	if err != nil {
-		if !isAppMissingErr(err) {
-			telemetry.SetError(span, err, "Get Argo Managed Resources")
+		if isAppMissingErr(err) {
+			span.RecordError(err)
 			return nil, nil
 		}
 
-		resources = new(application.ManagedResourcesResponse)
+		return nil, err
 	}
-	return resources.Items, err
+	return resources.Items, nil
 }
 
 func getArgoSettings(ctx context.Context, request checks.Request) (*settings.Settings, error) {


### PR DESCRIPTION
argocd returns 403 if an app doesn't exist; this logic was just wrong