### PR TITLE
remove application set revision check.

### DIFF
--- a/pkg/affected_apps/argocd_matcher.go
+++ b/pkg/affected_apps/argocd_matcher.go
@@ -77,7 +77,7 @@ func (a *ArgocdMatcher) AffectedApps(_ context.Context, changeList []string, tar
 	}
 
 	appsSlice := a.appsDirectory.FindAppsBasedOnChangeList(changeList, targetBranch)
-	appSetsSlice := a.appSetsDirectory.FindAppsBasedOnChangeList(changeList, targetBranch, repo)
+	appSetsSlice := a.appSetsDirectory.FindAppsBasedOnChangeList(changeList, repo)
 
 	// and return both apps and appSets
 	return AffectedItems{

--- a/pkg/appdir/appset_directory_test.go
+++ b/pkg/appdir/appset_directory_test.go
@@ -82,7 +82,6 @@ func TestAppSetDirectory_FindAppsBasedOnChangeList(t *testing.T) {
 			changeList: []string{
 				"appsets/httpdump/valid-appset.yaml",
 			},
-			targetBranch: "main",
 			mockFiles: map[string]string{
 				"appsets/httpdump/valid-appset.yaml": `
 apiVersion: argoproj.io/v1alpha1
@@ -180,7 +179,6 @@ spec:
 			changeList: []string{
 				"invalid-appset.yaml",
 			},
-			targetBranch: "main",
 			mockFiles: map[string]string{
 				"appsets/httpdump/invalid-appset.yaml": "invalid yaml content",
 			},
@@ -214,7 +212,7 @@ spec:
 				t.Fatalf("failed to create tmp folder %s", fatalErr)
 			}
 			d := &AppSetDirectory{}
-			result := d.FindAppsBasedOnChangeList(tt.changeList, tt.targetBranch, &git.Repo{Directory: tempDir})
+			result := d.FindAppsBasedOnChangeList(tt.changeList, &git.Repo{Directory: tempDir})
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
applicationsets was checking the manifest was targeting main, however there are cases where targetRevision may be using template e.g. `{{ .values.target }}` This causes the check to fail and does not perform applicationset checks.

This PR removes the check as this check is only required on the applications not applicationsets.

fixes https://github.com/zapier/kubechecks/issues/269  
