### PR TITLE
Fix CI

### DIFF
--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: composite
 
   steps:
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-qemu-action@v3
       with:
         image: tonistiigi/binfmt:latest
         platforms: all
@@ -32,7 +32,7 @@ runs:
       with: { version: "v${{ env.EARTHLY_TOOL_VERSION }}" }
 
     - name: login to registry
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -40,10 +40,12 @@ runs:
 
     - name: Build and push the Docker image
       shell: bash
+      env:
+        ACTIONS_STEP_DEBUG: "true"
       run: >-       
         ./earthly.sh 
         --push 
         +docker-multiarch
-        ${{ inputs.tag_latest != 'false' && format('--LATEST_IMAGE_NAME=ghcr.io/{0}:latest', github.repository) || '' }} 
+        ${{ inputs.tag_latest != 'false' && format('--LATEST_IMAGE_NAME=ghcr.io/{0}:latest', github.repository) || '' }}
         --GIT_TAG=${{ inputs.image_tag }}
         --IMAGE_NAME=ghcr.io/${{ github.repository }}:${{ inputs.image_tag }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -5,6 +5,10 @@ inputs:
   image_tag:
     description: The image tag
     required: true
+  push:
+    description: True to push image after building, false otherwise
+    required: false
+    default: "false"
   tag_latest:
     description: Tag latest as well as the provided tag
     default: "false"
@@ -44,7 +48,7 @@ runs:
         ACTIONS_STEP_DEBUG: "true"
       run: >-       
         ./earthly.sh 
-        --push 
+        ${{ inputs.push == 'true' && '--push' || '' }} 
         +docker-multiarch
         ${{ inputs.tag_latest != 'false' && format('--LATEST_IMAGE_NAME=ghcr.io/{0}:latest', github.repository) || '' }}
         --GIT_TAG=${{ inputs.image_tag }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -44,8 +44,6 @@ runs:
 
     - name: Build and push the Docker image
       shell: bash
-      env:
-        ACTIONS_STEP_DEBUG: "true"
       run: >-       
         ./earthly.sh 
         ${{ inputs.push == 'true' && '--push' || '' }} 

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -32,6 +32,7 @@ jobs:
       - uses: ./.github/actions/build-image
         id: build-image
         with:
+          push: '${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}'
           image_tag: ${{ env.FS_TAG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -39,3 +40,4 @@ jobs:
         with:
           message: |
             Temporary image available at `${{ steps.build-image.outputs.image }}`.
+        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name

--- a/.github/workflows/on_push_to_main.yaml
+++ b/.github/workflows/on_push_to_main.yaml
@@ -23,6 +23,7 @@ jobs:
 
       - uses: ./.github/actions/build-image
         with:
+          push: 'true'
           image_tag: ${{ env.GIT_TAG }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
GitHub has some limitations where pull requests that come from forks cannot create packages within the origin repo. This ensures that we can still create the PR images when sent to its own repo, but otherwise the push gets skipped.