### PR TITLE
fix: add missing `vcs-upload-url` flag for enterprise github

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ func init() {
 	)
 	boolFlag(flags, "persist-log-level", "Persists the set log level down to other module loggers.")
 	stringFlag(flags, "vcs-base-url", "VCS base url, useful if self hosting gitlab, enterprise github, etc.")
+	stringFlag(flags, "vcs-upload-url", "VCS upload url, required for enterprise github.")
 	stringFlag(flags, "vcs-type", "VCS type. One of gitlab or github. Defaults to gitlab.",
 		newStringOpts().
 			withChoices("github", "gitlab").

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,9 +66,9 @@ The full list of supported environment variables is described below:
 |`KUBECHECKS_SHOW_DEBUG_INFO`|Set to true to print debug info to the footer of MR comments.|`false`|
 |`KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE`|Sets the mode to use when tidying outdated comments. One of hide, delete.|`hide`|
 |`KUBECHECKS_VCS_BASE_URL`|VCS base url, useful if self hosting gitlab, enterprise github, etc.||
-|`KUBECHECKS_VCS_UPLOAD_URL`|VCS upload url, required for enterprise github.||
 |`KUBECHECKS_VCS_TOKEN`|VCS API token.||
 |`KUBECHECKS_VCS_TYPE`|VCS type. One of gitlab or github.|`gitlab`|
+|`KUBECHECKS_VCS_UPLOAD_URL`|VCS upload url, required for enterprise github.||
 |`KUBECHECKS_WEBHOOK_SECRET`|Optional secret key for validating the source of incoming webhooks.||
 |`KUBECHECKS_WEBHOOK_URL_BASE`|The endpoint to listen on for incoming PR/MR event webhooks. For example, 'https://checker.mycompany.com'.||
 |`KUBECHECKS_WEBHOOK_URL_PREFIX`|If your application is running behind a proxy that uses path based routing, set this value to match the path prefix. For example, '/hello/world'.||

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,6 +66,7 @@ The full list of supported environment variables is described below:
 |`KUBECHECKS_SHOW_DEBUG_INFO`|Set to true to print debug info to the footer of MR comments.|`false`|
 |`KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE`|Sets the mode to use when tidying outdated comments. One of hide, delete.|`hide`|
 |`KUBECHECKS_VCS_BASE_URL`|VCS base url, useful if self hosting gitlab, enterprise github, etc.||
+|`KUBECHECKS_VCS_UPLOAD_URL`|VCS upload url, required for enterprise github.||
 |`KUBECHECKS_VCS_TOKEN`|VCS API token.||
 |`KUBECHECKS_VCS_TYPE`|VCS type. One of gitlab or github.|`gitlab`|
 |`KUBECHECKS_WEBHOOK_SECRET`|Optional secret key for validating the source of incoming webhooks.||


### PR DESCRIPTION
When trying to use kubechecks with enterprise github I get the following error:
```
error="failed to create vcs client: failed to get user: GET https://api.github.com/user: 401 Bad credentials []"
```

```
configMap:
  create: true
  env:
    KUBECHECKS_VCS_BASE_URL: https://<redacted>/
    KUBECHECKS_VCS_UPLOAD_URL: https://<redacted>/
    KUBECHECKS_VCS_TYPE: github
```

Meaning it is still trying to connect to github proper. 

After checking the source, I believe the `KUBECHECKS_VCS_UPLOAD_URL` isn't being parsed, though is referenced in the Github client - https://github.com/zapier/kubechecks/blob/35dfcf6cf96c66d4893be723f5db45ebd629b047/pkg/vcs/github_client/client.go#L64

I wasn't able to properly get the local testing environment fully working due to ngrok mitm issues, but I believe this should resolve the issue as I saw the 401 error disappear in the pod output.