### PR TITLE
handle source.spec.helm.ignoreMissingValuesFiles = true

### DIFF
--- a/pkg/argo_client/manifests.go
+++ b/pkg/argo_client/manifests.go
@@ -334,7 +334,12 @@ func packageApp(ctx context.Context, source v1alpha1.ApplicationSource, refs []v
 				src := filepath.Join(refRepo.Directory, refPath)
 				dst := filepath.Join(tempDir, refPath)
 				if err = copyFile(src, dst); err != nil {
-					return "", errors.Wrapf(err, "failed to copy referenced value file: %q", valueFile)
+					// handle source.spec.helm.ignoreMissingValues = true
+					if errors.Is(err, os.ErrNotExist) && source.Helm.IgnoreMissingValueFiles {
+						log.Debug().Str("valueFile", valueFile).Msg("ignore missing values file, because source.Helm.IgnoreMissingValueFiles is true")
+					} else {
+						return "", errors.Wrapf(err, "failed to copy referenced value file: %q", valueFile)
+					}
 				}
 
 				relPath, err := filepath.Rel(tempAppDir, dst)


### PR DESCRIPTION
If the helm source has `ignoreMissingValuesFiles = true` kubechecks should ignore values file copy errors where the file is not found.

In one of our multi source appsets we reference a bunch of optional values files that allow overriding values at different levels / layers / environments / tiers / providers / whatever.

```
failed to generate manifests: failed to package application: failed to copy referenced value file: "$values/apps/aws-provider/default.values.yaml": open /tmp/kubechecks-repo-4238925250/apps/aws-provider/default.values.yaml: no such file or directory
```