### PR TITLE
Add initContainers support

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.4.5
+version: 0.4.6
 type: application
 maintainers:
   - name: zapier

--- a/charts/kubechecks/templates/deployment.yaml
+++ b/charts/kubechecks/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.deployment.podSecurityContext | nindent 8 }}
+      {{- with .Values.deployment.initContainers }}
+      initContainers:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.deployment.image }}

--- a/charts/kubechecks/templates/service.yaml
+++ b/charts/kubechecks/templates/service.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kubechecks.fullname" . }}
+  annotations:
+    {{ .Values.service.annotations | toYaml | nindent 4 }}
   labels:
     {{- include "kubechecks.labels" . | nindent 4 }}
 spec:

--- a/charts/kubechecks/values.schema.json
+++ b/charts/kubechecks/values.schema.json
@@ -102,6 +102,9 @@
         "securityContext": {
           "type": "object"
         },
+        "initContainers": {
+          "type": "array"
+        },
         "startupProbe": {
           "type": "object"
         },
@@ -192,6 +195,9 @@
         },
         "name": {
           "type": "string"
+        },
+        "annotations": {
+          "$ref": "#/$defs/key-value-map"
         }
       }
     },


### PR DESCRIPTION
Currently, there is no option to configure Kubecheck to authenticate against OCI registries like GCR/GAR. By adding support for initContainers, users can set up credential helpers such as docker-credential-gcr to generate a config.json for Docker authentication, the initContainer  can also copies the docker-credential-gcr binary into the main Kubecheck container, allowing it to successfully fetch tokens and authenticate

