### PR TITLE
feat: role and rolebinding template change to allow name override.

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.5.0
+version: 0.5.1
 type: application
 maintainers:
   - name: zapier

--- a/charts/kubechecks/templates/role.yaml
+++ b/charts/kubechecks/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: kubechecks
+  name: {{ include "kubechecks.fullname" . }}
   namespace: {{ .Values.argocd.namespace }}
 rules:
   - apiGroups:

--- a/charts/kubechecks/templates/rolebinding.yaml
+++ b/charts/kubechecks/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: kubechecks
+  name: {{ include "kubechecks.fullname" . }}
   namespace: {{ .Values.argocd.namespace }}
 roleRef:
   kind: Role


### PR DESCRIPTION
1. change to use kubechecks.fullname for the role name and role binding name.