### PR TITLE
fix: tilt local development

### DIFF
--- a/localdev/kubechecks/values.yaml
+++ b/localdev/kubechecks/values.yaml
@@ -1,6 +1,8 @@
 configMap:
   create: true
   env:
+    GRPC_ENFORCE_ALPN_ENABLED: false
+    KUBECHECKS_ADDITIONAL_APPS_NAMESPACES: "*"
     KUBECHECKS_LOG_LEVEL: debug
     KUBECHECKS_ENABLE_WEBHOOK_CONTROLLER: "false"
     KUBECHECKS_ARGOCD_API_INSECURE: "true"
@@ -40,3 +42,6 @@ secrets:
 
 reloader:
   enabled: true
+
+argocd:
+  namespace: kubechecks


### PR DESCRIPTION
Since the grpc update and others, tilt local dev is not starting up correctly.
This will fix the issue of not starting up.

1. specify the argocd namespace to kubechecks.
2. set GRPC_ENFORCE_ALPN_ENABLED to false as tilt-argocd server does not have a valid cert
