### PR TITLE
feat: add flag to include .git

### DIFF
--- a/pkg/argo_client/manifests.go
+++ b/pkg/argo_client/manifests.go
@@ -153,7 +153,13 @@ func (a *ArgoClient) generateManifests(ctx context.Context, app v1alpha1.Applica
 	}
 
 	log.Info().Msg("compressing files")
-	f, filesWritten, checksum, err := tgzstream.CompressFiles(packageDir, []string{"*"}, []string{".git"})
+
+	exclude := []string{}
+	if !a.cfg.ArgoCDIncludeDotGit {
+		exclude = append(exclude, ".git")
+	}
+
+	f, filesWritten, checksum, err := tgzstream.CompressFiles(packageDir, []string{"*"}, exclude)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compress files: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ type ServerConfig struct {
 	ArgoCDRepositoryEndpoint string `mapstructure:"argocd-repository-endpoint"`
 	ArgoCDRepositoryInsecure bool   `mapstructure:"argocd-repository-insecure"`
 	ArgoCDSendFullRepository bool   `mapstructure:"argocd-send-full-repository"`
+	ArgoCDIncludeDotGit      bool   `mapstructure:"argocd-include-dot-git"`
 	KubernetesConfig         string `mapstructure:"kubernetes-config"`
 	KubernetesType           string `mapstructure:"kubernetes-type"`
 	KubernetesClusterID      string `mapstructure:"kubernetes-clusterid"`


### PR DESCRIPTION
Hello,

some tools like `git-crypt` require to receive the repository metadata as well and are commonly used to encrypt sensitive data alongside k8s configurations, so I think this should be supported.