### PR TITLE
feat: Support changing revisionHistoryLimit from kubernetes default of 10

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.5.3
+version: 0.5.4
 type: application
 maintainers:
   - name: zapier

--- a/charts/kubechecks/templates/deployment.yaml
+++ b/charts/kubechecks/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- end}}
   labels: {{- include "kubechecks.labels" . | nindent 4 }}
 spec:
+  revisionHistoryLimit: {{ .Values.deployment.revisionHistoryLimit }}
   replicas: {{ .Values.deployment.replicaCount }}
   selector:
     matchLabels:

--- a/charts/kubechecks/values.schema.json
+++ b/charts/kubechecks/values.schema.json
@@ -93,6 +93,9 @@
         "readinessProbe": {
           "type": "object"
         },
+        "revisionHistoryLimit": {
+          "type": "integer"
+        },
         "replicaCount": {
           "type": "integer"
         },

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -40,6 +40,7 @@ deployment:
       memory: 256Mi
       cpu: 200m
 
+  revisionHistoryLimit: 10
   replicaCount: 1
 
   image:


### PR DESCRIPTION
When using ArgoCD in a full gitops context, revision history limit clutters the UI with unused ReplicaSets. Allowing configuration of the revision history limit allows users to set this to a different value, such as `0`. With a revision history limit of `0`, Kubernetes will auto-remove any ReplicaSet other than the current active ReplicaSet. I have set a default of `10` so the change is backwards compatible, this is the Kubernetes default.