### PR TITLE
feat: improve kustomization walk for helmCharts section

### DIFF
--- a/pkg/kustomize/process.go
+++ b/pkg/kustomize/process.go
@@ -44,7 +44,7 @@ func processDir(sourceFS fs.FS, relBase string) (files []string, dirs []string, 
 	var filesOrDirectories []string
 	filesOrDirectories = append(filesOrDirectories, kust.Bases...) // nolint:staticcheck // deprecated doesn't mean unused
 	filesOrDirectories = append(filesOrDirectories, kust.Resources...)
-
+	filesOrDirectories = append(filesOrDirectories, getValuesFromKustomizationHelm(&kust)...)
 	var directories []string
 	directories = append(directories, kust.Components...)
 
@@ -153,4 +153,12 @@ func isRemoteResource(resource string) bool {
 	}
 
 	return false
+}
+
+// getValuesFromKustomizationHelm will parse the helmCharts sections' valueFile field and return them as a slice of strings.
+func getValuesFromKustomizationHelm(kust *types.Kustomization) (files []string) {
+	for _, helm := range kust.HelmCharts {
+		files = append(files, helm.ValuesFile)
+	}
+	return files
 }

--- a/pkg/kustomize/process_test.go
+++ b/pkg/kustomize/process_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/kustomize/api/types"
 	_ "sigs.k8s.io/kustomize/api/types"
 )
 
@@ -232,4 +233,41 @@ dummy:
 		assert.NoError(t, err)
 		assert.Contains(t, files, "testdir/values-dummy.yaml")
 	})
+}
+
+func Test_getValuesFromKustomizationHelm(t *testing.T) {
+	type args struct {
+		kust *types.Kustomization
+	}
+	tests := []struct {
+		name      string
+		args      args
+		wantFiles []string
+	}{
+		{
+			name: "normal",
+			args: args{
+				kust: &types.Kustomization{
+					HelmCharts: []types.HelmChart{
+						{Name: "dummy", ValuesFile: "values-dummy.yaml"},
+					},
+				},
+			},
+			wantFiles: []string{"values-dummy.yaml"},
+		},
+		{
+			name: "helmChart is nil.",
+			args: args{
+				kust: &types.Kustomization{
+					HelmCharts: nil,
+				},
+			},
+			wantFiles: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.wantFiles, getValuesFromKustomizationHelm(tt.args.kust), "getValuesFromKustomizationHelm(%v)", tt.args.kust)
+		})
+	}
 }

--- a/pkg/kustomize/process_test.go
+++ b/pkg/kustomize/process_test.go
@@ -217,7 +217,7 @@ helmCharts:
 `
 		valueContent := `
 dummy:
-  lables:
+  labels:
     release: dummy
 `
 		sourceFS := fstest.MapFS{

--- a/pkg/kustomize/process_test.go
+++ b/pkg/kustomize/process_test.go
@@ -203,4 +203,33 @@ resources:
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to stat testdir/missing-resource.yaml")
 	})
+	t.Run("helmChart", func(t *testing.T) {
+		kustContent := `
+helmCharts:
+  - name: dummy
+    repo: https://dummy.local/repo
+    version: 1.2.3
+    releaseName: dummy
+    namespace: dumy
+    includeCRDs: true
+    valuesFile: values-dummy.yaml
+`
+		valueContent := `
+dummy:
+  lables:
+    release: dummy
+`
+		sourceFS := fstest.MapFS{
+			"testdir/kustomization.yaml": &fstest.MapFile{
+				Data: []byte(kustContent),
+			},
+			"testdir/values-dummy.yaml": &fstest.MapFile{
+				Data: []byte(valueContent),
+			},
+		}
+
+		files, _, err := processDir(sourceFS, "testdir")
+		assert.NoError(t, err)
+		assert.Contains(t, files, "testdir/values-dummy.yaml")
+	})
 }

--- a/pkg/kustomize/process_test.go
+++ b/pkg/kustomize/process_test.go
@@ -210,7 +210,7 @@ helmCharts:
     repo: https://dummy.local/repo
     version: 1.2.3
     releaseName: dummy
-    namespace: dumy
+    namespace: dummy
     includeCRDs: true
     valuesFile: values-dummy.yaml
 `


### PR DESCRIPTION
current kustomization.yaml walk does not parse the helmCharts section. 
This PR is to add ability to add these values file per chart and send to the argo-cd-repo server.
