### PR TITLE
Allow multiple kubechecks instances with the same token

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -119,6 +119,9 @@ func init() {
 		newStringOpts().
 			withDefault("kubechecks again"))
 	stringSliceFlag(flags, "additional-apps-namespaces", "Additional namespaces other than the ArgoCDNamespace to monitor for applications.")
+	stringFlag(flags, "identifier", "Identifier for the kubechecks instance. Used to differentiate between multiple kubechecks instances.",
+		newStringOpts().
+			withDefault(""))
 
 	panicIfError(viper.BindPFlags(flags))
 	setupLogOutput()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,6 +54,7 @@ The full list of supported environment variables is described below:
 |`KUBECHECKS_GITHUB_APP_ID`|Github App ID.|`0`|
 |`KUBECHECKS_GITHUB_INSTALLATION_ID`|Github Installation ID.|`0`|
 |`KUBECHECKS_GITHUB_PRIVATE_KEY`|Github App Private Key.||
+|`KUBECHECKS_IDENTIFIER`|Identifier for the kubechecks instance. Used to differentiate between multiple kubechecks instances.||
 |`KUBECHECKS_KUBERNETES_CLUSTERID`|Kubernetes Cluster ID, must be specified if kubernetes-type is eks.||
 |`KUBECHECKS_KUBERNETES_CONFIG`|Path to your kubernetes config file, used to monitor applications.||
 |`KUBECHECKS_KUBERNETES_TYPE`|Kubernetes Type One of eks, or local.|`local`|

--- a/localdev/kubechecks/values.yaml
+++ b/localdev/kubechecks/values.yaml
@@ -24,7 +24,7 @@ configMap:
     # KUBECHECKS_SCHEMAS_LOCATION: https://github.com/zapier/kubecheck-schemas.git
     KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE: "delete"
     KUBECHECKS_ENABLE_CONFTEST: "false"
-
+    KUBECHECKS_IDENTIFIER: "test"
 
 deployment:
   annotations:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,6 +85,7 @@ type ServerConfig struct {
 	MaxQueueSize             int64         `mapstructure:"max-queue-size"`
 	MaxConcurrenctChecks     int           `mapstructure:"max-concurrenct-checks"`
 	ReplanCommentMessage     string        `mapstructure:"replan-comment-msg"`
+	Identifier               string        `mapstructure:"identifier"`
 }
 
 func New() (ServerConfig, error) {

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -275,7 +275,10 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 
 	if len(ce.affectedItems.Applications) <= 0 && len(ce.affectedItems.ApplicationSets) <= 0 {
 		ce.logger.Info().Msg("No affected apps or appsets, skipping")
-		if _, err := ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, "No changes"); err != nil {
+		if _, err := ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf(`
+		## Kubechecks %s Report
+		No changes
+		`, ce.ctr.Config.Identifier)); err != nil {
 			return errors.Wrap(err, "failed to post changes")
 		}
 		return nil
@@ -325,7 +328,7 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 
 	ce.logger.Info().Msg("Finished")
 
-	comment := ce.vcsNote.BuildComment(ctx, start, ce.pullRequest.SHA, ce.ctr.Config.LabelFilter, ce.ctr.Config.ShowDebugInfo)
+	comment := ce.vcsNote.BuildComment(ctx, start, ce.pullRequest.SHA, ce.ctr.Config.LabelFilter, ce.ctr.Config.ShowDebugInfo, ce.ctr.Config.Identifier)
 
 	if err = ce.ctr.VcsClient.UpdateMessage(ctx, ce.vcsNote, comment); err != nil {
 		return errors.Wrap(err, "failed to push comment")
@@ -403,5 +406,5 @@ func (ce *CheckEvent) createNote(ctx context.Context) (*msg.Message, error) {
 
 	ce.logger.Info().Msgf("Creating note")
 
-	return ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, ":hourglass: kubechecks running ... ")
+	return ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf(":hourglass: kubechecks %s running ... ", ce.ctr.Config.Identifier))
 }

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -406,5 +406,7 @@ func (ce *CheckEvent) createNote(ctx context.Context) (*msg.Message, error) {
 
 	ce.logger.Info().Msgf("Creating note")
 
-	return ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf(":hourglass: kubechecks %s running ... ", ce.ctr.Config.Identifier))
+	return ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf(`
+	## Kubechecks %s Report
+	:hourglass: kubechecks running ... `, ce.ctr.Config.Identifier))
 }

--- a/pkg/msg/message.go
+++ b/pkg/msg/message.go
@@ -142,14 +142,14 @@ func (m *Message) buildFooter(start time.Time, commitSHA, labelFilter string, sh
 }
 
 // BuildComment iterates the map of all apps in this message, building a final comment from their current state
-func (m *Message) BuildComment(ctx context.Context, start time.Time, commitSHA, labelFilter string, showDebugInfo bool) string {
+func (m *Message) BuildComment(ctx context.Context, start time.Time, commitSHA, labelFilter string, showDebugInfo bool, identifier string) string {
 	_, span := tracer.Start(ctx, "buildComment")
 	defer span.End()
 
 	names := getSortedKeys(m.apps)
 
 	var sb strings.Builder
-	sb.WriteString("# Kubechecks Report\n")
+	sb.WriteString(fmt.Sprintf("# Kubechecks %s Report\n", identifier))
 
 	updateWritten := false
 	for _, appName := range names {

--- a/pkg/msg/message_test.go
+++ b/pkg/msg/message_test.go
@@ -31,8 +31,8 @@ func TestBuildComment(t *testing.T) {
 	}
 	m := NewMessage("message", 1, 2, fakeEmojiable{":test:"})
 	m.apps = appResults
-	comment := m.BuildComment(context.TODO(), time.Now(), "commit-sha", "label-filter", false)
-	assert.Equal(t, `# Kubechecks Report
+	comment := m.BuildComment(context.TODO(), time.Now(), "commit-sha", "label-filter", false, "test-identifier")
+	assert.Equal(t, `# Kubechecks test-identifier Report
 <details>
 <summary>
 
@@ -79,8 +79,8 @@ func TestBuildComment_SkipUnchanged(t *testing.T) {
 
 	m := NewMessage("message", 1, 2, fakeEmojiable{":test:"})
 	m.apps = appResults
-	comment := m.BuildComment(context.TODO(), time.Now(), "commit-sha", "label-filter", false)
-	assert.Equal(t, `# Kubechecks Report
+	comment := m.BuildComment(context.TODO(), time.Now(), "commit-sha", "label-filter", false, "test-identifier")
+	assert.Equal(t, `# Kubechecks test-identifier Report
 <details>
 <summary>
 
@@ -183,7 +183,7 @@ func TestMultipleItemsWithNewlines(t *testing.T) {
 		Summary: "summary-2",
 		Details: "detail-2",
 	})
-	result := message.BuildComment(context.TODO(), time.Now(), "commit-sha", "label-filter", false)
+	result := message.BuildComment(context.TODO(), time.Now(), "commit-sha", "label-filter", false, "test-identifier")
 
 	// header rows need double newlines before and after
 	index := 0

--- a/pkg/vcs/github_client/message.go
+++ b/pkg/vcs/github_client/message.go
@@ -86,7 +86,7 @@ func (c *Client) pruneOldComments(ctx context.Context, pr vcs.PullRequest, comme
 	log.Debug().Msgf("Pruning messages from PR %d in repo %s", pr.CheckID, pr.FullName)
 
 	for _, comment := range comments {
-		if strings.EqualFold(comment.GetUser().GetLogin(), c.username) {
+		if strings.EqualFold(comment.GetUser().GetLogin(), c.username) || strings.Contains(*comment.Body, fmt.Sprintf("Kubechecks %s Report", c.cfg.Identifier)) {
 			_, err := c.googleClient.Issues.DeleteComment(ctx, pr.Owner, pr.Name, *comment.ID)
 			if err != nil {
 				return fmt.Errorf("failed to delete comment: %w", err)
@@ -104,7 +104,7 @@ func (c *Client) hideOutdatedMessages(ctx context.Context, pr vcs.PullRequest, c
 	log.Debug().Msgf("Hiding kubecheck messages in PR %d in repo %s", pr.CheckID, pr.FullName)
 
 	for _, comment := range comments {
-		if strings.EqualFold(comment.GetUser().GetLogin(), c.username) {
+		if strings.EqualFold(comment.GetUser().GetLogin(), c.username) || strings.Contains(*comment.Body, fmt.Sprintf("Kubechecks %s Report", c.cfg.Identifier)) {
 			// Github API does not expose minimizeComment API. IT's only available from the GraphQL API
 			// https://docs.github.com/en/graphql/reference/mutations#minimizecomment
 			var m struct {


### PR DESCRIPTION
Allow multiple kubechecks with the same token. 

When running multiple kubechecks with the same token, comments are hidden by one of the kubechecks regardless of which instance created it. Take for instance you have two argocd instances each with different kubechecks running. Both argocds read from a single centralised repo. When you make an MR, the kubechecks from argocd A, will hide the comments from the kubechecks on argocd B. Hence the need for this feature. 