### PR TITLE
fix: must parse kustomization.yaml

### DIFF
--- a/pkg/appdir/vcstoargomap.go
+++ b/pkg/appdir/vcstoargomap.go
@@ -2,6 +2,7 @@ package appdir
 
 import (
 	"io/fs"
+	"path/filepath"
 
 	"github.com/argoproj/argo-cd/v2/pkg/apis/application/v1alpha1"
 	"github.com/rs/zerolog/log"
@@ -71,7 +72,8 @@ func (v2a VcsToArgoMap) WalkKustomizeApps(cloneURL string, rootFS fs.FS) *AppDir
 	for _, app := range apps {
 		appPath := app.Spec.GetSource().Path
 
-		kustomizeFiles, kustomizeDir, err := kustomize.ProcessKustomizationFile(rootFS, appPath)
+		kustomizePath := filepath.Join(appPath, "kustomization.yaml")
+		kustomizeFiles, kustomizeDir, err := kustomize.ProcessKustomizationFile(rootFS, kustomizePath)
 		if err != nil {
 			log.Error().Err(err).Msgf("failed to parse kustomize.yaml in %s", appPath)
 		}

--- a/pkg/kustomize/process.go
+++ b/pkg/kustomize/process.go
@@ -1,6 +1,7 @@
 package kustomize
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -13,8 +14,15 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+var ErrUnexpectedFilename = errors.New("kustomization file must be called kustomization.yaml")
+
 // ProcessKustomizationFile processes a kustomization file and returns all the files and directories it references.
 func ProcessKustomizationFile(sourceFS fs.FS, relKustomizationPath string) (files, dirs []string, err error) {
+	filename := filepath.Base(relKustomizationPath)
+	if filename != "kustomization.yaml" {
+		return nil, nil, fmt.Errorf("%q was unexpected: %w", relKustomizationPath, ErrUnexpectedFilename)
+	}
+
 	dirName := filepath.Dir(relKustomizationPath)
 
 	proc := processor{

--- a/pkg/kustomize/process_test.go
+++ b/pkg/kustomize/process_test.go
@@ -70,7 +70,7 @@ func TestProcessDir(t *testing.T) {
 				return nil, fs.ErrNotExist
 			},
 		}
-		_, _, err := ProcessKustomizationFile(mfs, filepath.Join("testdir", "kustomation.yaml"))
+		_, _, err := ProcessKustomizationFile(mfs, filepath.Join("testdir", "kustomization.yaml"))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to open file")
 	})


### PR DESCRIPTION
This was causing apps to be seen as owning their parent directories. In other words, an app called "argocd" in a repo folder of "/apps/infrastructure/production/argocd" was seen to be changed any time any file was changed under "/apps/infrastructure/production", causing far more work to be done than is necessary in some circumstances.

Fixes #372 