### PR TITLE
clean up dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     ignore:
       # projects that aren't at 1.0 yet tend to have breaking changes,
       # so we don't batch those up with this "stable small changes" group
-      - { versions: "<1" }
+      - dependency-name: "*"
+        versions: "<1"
     package-ecosystem: "gomod"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - directory: "/"
+    groups:
+      minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      versions: "<1"
+    package-ecosystem: "gomod"
+    schedule:
+      interval: "weekly"
+
+  - directory: "/"
+    package-ecosystem: "gomod"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
     ignore:
       # projects that aren't at 1.0 yet tend to have breaking changes,
       # so we don't batch those up with this "stable small changes" group
-      versions: "<1"
+      versions:
+        - "<1"
     package-ecosystem: "gomod"
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # projects that aren't at 1.0 yet tend to have breaking changes,
+      # so we don't batch those up with this "stable small changes" group
       versions: "<1"
     package-ecosystem: "gomod"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,3 @@ updates:
     package-ecosystem: "gomod"
     schedule:
       interval: "weekly"
-
-  - directory: "/"
-    package-ecosystem: "gomod"
-    schedule:
-      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,7 @@ updates:
     ignore:
       # projects that aren't at 1.0 yet tend to have breaking changes,
       # so we don't batch those up with this "stable small changes" group
-      versions:
-        - "<1"
+      - { versions: "<1" }
     package-ecosystem: "gomod"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
1. group minor & patch updates (over 1.0) into a single MR
2. all others get their own MRs