### PR TITLE
Adds default namespace to kubechecks resources

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.5.5
+version: 0.5.6
 type: application
 maintainers:
   - name: zapier

--- a/charts/kubechecks/templates/_helpers.tpl
+++ b/charts/kubechecks/templates/_helpers.tpl
@@ -67,3 +67,11 @@ Create the name of the secret file to use
 {{- define "kubechecks.secretsName" -}}
 {{- tpl .Values.secrets.name . }}
 {{- end -}}
+
+
+{{/*
+Returns namespace for kubechecks resources
+*/}}
+{{- define "kubechecks.releaseNamespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end -}}

--- a/charts/kubechecks/templates/configmap.yaml
+++ b/charts/kubechecks/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kubechecks.name" . }}
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   labels:
 {{ include "kubechecks.labels" . | indent 4 }}
 data:

--- a/charts/kubechecks/templates/deployment.yaml
+++ b/charts/kubechecks/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kubechecks.fullname" . }}
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   {{- with .Values.deployment.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end}}

--- a/charts/kubechecks/templates/hpa.yaml
+++ b/charts/kubechecks/templates/hpa.yaml
@@ -13,6 +13,7 @@ apiVersion: {{ $apiVersion }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kubechecks.fullname" . }}
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   labels:
     {{- include "kubechecks.labels" . | nindent 4 }}
 spec:

--- a/charts/kubechecks/templates/ingress.yaml
+++ b/charts/kubechecks/templates/ingress.yaml
@@ -6,6 +6,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "kubechecks.fullname" . }}
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   annotations:
 {{ toYaml .Values.ingress.annotations | indent 4 }}
   labels:

--- a/charts/kubechecks/templates/secrets.yaml
+++ b/charts/kubechecks/templates/secrets.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ include "kubechecks.secretsName" . }}"
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   labels:
     {{- include "kubechecks.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/kubechecks/templates/service.yaml
+++ b/charts/kubechecks/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kubechecks.fullname" . }}
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   annotations:
     {{ .Values.service.annotations | toYaml | nindent 4 }}
   labels:

--- a/charts/kubechecks/templates/serviceaccount.yaml
+++ b/charts/kubechecks/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kubechecks.serviceAccountName" . }}
+  namespace: {{ include "kubechecks.releaseNamespace" . }}
   labels:
     {{- include "kubechecks.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -1,4 +1,8 @@
 # Labels to apply to all resources created by this Helm chart
+
+# Overrides namespace for kubechecks resources. Otherwise defaults to ".Release.Namespace"
+namespaceOverride: ""
+
 argocd:
   namespace: argocd
 


### PR DESCRIPTION
- Sets a default namespace (uses `.Release.Namespace` ) on the necessary kubechecks resources.
- Provides an option to override the default release namespace.
- Bumps patch version of the chart
- Closes #358 