### PR TITLE
feat: remote set branch after shallow clone

### DIFF
--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -120,6 +120,16 @@ func (r *Repo) shallowClone(ctx context.Context) error {
 		return err
 	}
 
+	// Set all branches to be fetched to allow checking out any branch
+	// https://github.com/zapier/kubechecks/issues/407#issuecomment-2850431802
+	remoteSetBranchesArgs := []string{"remote", "set-branches", "origin", "*"}
+	cmd = r.execGitCommand(remoteSetBranchesArgs...)
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		log.Error().Err(err).Msgf("unable to set remote branches, %s", out)
+		return err
+	}
+
 	if r.BranchName != "HEAD" {
 		// Fetch SHA
 		args = []string{"fetch", "origin", r.BranchName, "--depth", "1"}

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -182,6 +182,18 @@ func (r *Repo) GetRemoteHead() (string, error) {
 	return branchName, nil
 }
 
+func (r *Repo) GetCurrentBranch() (string, error) {
+	cmd := r.execGitCommand("rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to determine which branch HEAD points to")
+	}
+
+	branchName := strings.TrimSpace(string(out))
+
+	return branchName, nil
+}
+
 func (r *Repo) MergeIntoTarget(ctx context.Context, ref string) error {
 	// Merge the last commit into a tmp branch off of the target branch
 	_, span := tracer.Start(ctx, "Repo - RepoMergeIntoTarget",

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -103,4 +103,7 @@ func TestRepoGetRemoteHead(t *testing.T) {
 	branch, err := repo.GetRemoteHead()
 	require.NoError(t, err)
 	assert.Equal(t, "main", branch)
+	currentBranch, err := repo.GetCurrentBranch()
+	require.NoError(t, err)
+	assert.Equal(t, "gh-pages", currentBranch)
 }

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -94,6 +94,7 @@ func TestRepoGetRemoteHead(t *testing.T) {
 
 	repo := New(cfg, "https://github.com/zapier/kubechecks.git", "")
 	repo.Shallow = true
+	repo.BranchName = "gh-pages"
 	err := repo.Clone(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Run `git remote set branch "*"` after shallow clone

Closes #407 