### PR TITLE
fix: narrow diff to only include changes from the source branch

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,36 +69,38 @@ To get started do the following:
 
 * Copy the `.secret.example` and set required values.
 
-    ```
+    ```sh
     cp .secret.example .secret
     ```
-  You will need to fill in either `GITLAB_TOKEN` or `GITLAB_TOKEN`  
-  If you are testing with GITHUB, please set the tilt_config.json file to specify the vcs-type as the default is `gitlab`.  
-  The token you specify must have ability to get repositories, add/delete comment and webhooks.  
-    ```
-    {
-      "vcs-type": "github"
-    }
-    ```
+
+    You will need to fill in either `GITLAB_TOKEN` or `GITLAB_TOKEN`  
+    If you are testing with GITHUB, please set the tilt_config.json file to specify the vcs-type as the default is `gitlab`:
+
+      ```json title="tilt_config.json"
+      {
+        "vcs-type": "github"
+      }
+      ```
+
+    The token you specify must have ability to get repositories, add/delete comment and webhooks.
 
 * From the root directory of this repo:
 
-    ```
+    ```sh
     tilt up
     ```
 
 You should see output like:
 
-    ```
-    Tilt started on http://localhost:10350/
-    v0.30.13, built 2022-12-05
+```
+Tilt started on http://localhost:10350/
+v0.30.13, built 2022-12-05
 
-    (space) to open the browser
-    (s) to stream logs (--stream=true)
-    (t) to open legacy terminal mode (--legacy=true)
-    (ctrl-c) to exit
-
-    ```
+(space) to open the browser
+(s) to stream logs (--stream=true)
+(t) to open legacy terminal mode (--legacy=true)
+(ctrl-c) to exit
+```
 
 In the background Tilt has started building and deploying resources.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,13 +69,13 @@ To get started do the following:
 
 * Copy the `.secret.example` and set required values.
 
-    ```console
+    ```
     cp .secret.example .secret
     ```
   You will need to fill in either `GITLAB_TOKEN` or `GITLAB_TOKEN`  
-  If you are testing with GITHUB, please set the tile_config.json file to specify the vcs-type as the default is `gitlab`.  
+  If you are testing with GITHUB, please set the tilt_config.json file to specify the vcs-type as the default is `gitlab`.  
   The token you specify must have ability to get repositories, add/delete comment and webhooks.  
-    ```json
+    ```
     {
       "vcs-type": "github"
     }
@@ -83,7 +83,7 @@ To get started do the following:
 
 * From the root directory of this repo:
 
-    ```console
+    ```
     tilt up
     ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,3 +9,10 @@ theme:
 
 markdown_extensions:
   - attr_list
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -425,7 +425,7 @@ func (r *Repo) GetListOfChangedFiles(ctx context.Context) ([]string, error) {
 
 	var fileList []string
 
-	cmd := r.execGitCommand("diff", "--name-only", fmt.Sprintf("%s/%s", "origin", r.BranchName))
+	cmd := r.execGitCommand("diff", "--name-only", fmt.Sprintf("origin/%s...HEAD", r.BranchName))
 	pipe, _ := cmd.StdoutPipe()
 	var wg sync.WaitGroup
 	scanner := bufio.NewScanner(pipe)


### PR DESCRIPTION
Change the logic to show diffs introduced in the source branch, rather than all diffs between the source branch and target. This provides a more focused and accurate analysis of kubechecks proposed changes on PRs.
Additionally, this PR includes minor syntax fixes to the contributing.md document.

**The Problem:**
Previously, the comparison logic used `git diff origin/main..HEAD`, which would show all accumulated differences between the two branches. This could lead to confusing or irrelevant results, especially if `main` had moved forward since the feature branch was created.

**The Solution**
this PR updates the `git diff` command to use the triple-dot notation (`git diff origin/main...HEAD`). The result is a diff that only includes the changes made in the pull request. 

this resolves #406

Key Changes:
* Modified the `GetListOfChangedFiles` function to use `git diff ...` for more precise change detection.
* Corrected minor issues in `contributing.md`.

NOTE: Please be aware that this change will have no effect if `KUBECHECKS_REPO_SHALLOW_CLONE` is set to `true`. This is because the comparison logic won't be able to find the common base commit, which will result in a full diff being generated
