### PR TITLE
Bump kubeconform to v0.7.0

### DIFF
--- a/.github/workflows/on_pull_request_go.yaml
+++ b/.github/workflows/on_pull_request_go.yaml
@@ -12,6 +12,10 @@ jobs:
   ci-golang:
     runs-on: ubuntu-22.04
     steps:
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+
       - uses: actions/checkout@v3
 
       - uses: djeebus/parse-tool-versions@v2.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,7 @@ golangci-lint 2.1.6
 helm 3.16.3
 helm-cr 1.6.1
 helm-ct 3.11.0
-kubeconform 0.6.7
+kubeconform 0.7.0
 kustomize 5.6.0
 mockery 3.3.4
 tilt 0.33.2

--- a/Earthfile
+++ b/Earthfile
@@ -177,7 +177,7 @@ test-helm:
     FROM quay.io/helmpack/chart-testing:v${CHART_TESTING_VERSION}
 
     # install kubeconform
-    ARG KUBECONFORM_VERSION="0.6.4"
+    ARG KUBECONFORM_VERSION="0.7.0"
     RUN FILE=kubeconform.tgz \
         && URL=https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-linux-${USERARCH}.tar.gz \
         && wget ${URL} \

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
 	github.com/xanzy/go-gitlab v0.114.0
-	github.com/yannh/kubeconform v0.6.4
+	github.com/yannh/kubeconform v0.7.0
 	github.com/ziflex/lecho/v3 v3.8.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.58.0
 	go.opentelemetry.io/otel v1.36.0
@@ -248,7 +248,7 @@ require (
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/shteou/go-ignore v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -996,8 +996,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
-github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sashabaranov/go-openai v1.40.1 h1:bJ08Iwct5mHBVkuvG6FEcb9MDTfsXdTYPGjYLRdeTEU=
 github.com/sashabaranov/go-openai v1.40.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -1108,8 +1108,8 @@ github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQ
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yannh/kubeconform v0.6.4 h1:P8cQpK+K35qv8JOcjHQcTvD80SwwSDgHfMXyXrZ4rRY=
-github.com/yannh/kubeconform v0.6.4/go.mod h1:vl5ZLUE6h0xRd2qB0Drv9cc9sjZnjDYjSaexbfNE9WM=
+github.com/yannh/kubeconform v0.7.0 h1:ZFfniR8VChrWQxaxTUGnNrxw8RIDkjVBrjdhXSamwjw=
+github.com/yannh/kubeconform v0.7.0/go.mod h1:oHO1wjM16sTRW6s41HJUox+tD69qOTE5ZVQ9HeqX+xM=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
The current version of kubeconform doesn't support the necessary duration formats used by Kubernetes. This is fixed in version 0.7.0 by this [PR](https://github.com/yannh/kubeconform/commit/e65429b1e5990dd019ebb7b5642dcd22a3e9cd13)

Before:
<img width="741" alt="image" src="https://github.com/user-attachments/assets/69e4eeb3-aec7-44ab-b03b-1f176bebe349" />

After:
<img width="725" alt="image" src="https://github.com/user-attachments/assets/acb650c7-91fd-49f9-9cd7-714056d8aede" />

