### PR TITLE
fix: censor githubApp token in logs

### DIFF
--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -116,6 +116,8 @@ func CreateGithubClient(ctx context.Context, cfg config.ServerConfig) (*Client, 
 		}
 
 		vcsToken = response.Token
+		// this is so that we can censor the token in the logs
+		cfg.VcsToken = vcsToken
 
 		expirationDuration := time.Until(response.ExpiresAt)
 		interval := expirationDuration / 2
@@ -180,6 +182,8 @@ func (c *Client) refreshToken(ctx context.Context, cfg config.ServerConfig, inte
 					return errors.Wrap(err, "failed to refresh github app token")
 				}
 
+				// this is so that we can censor the token in the logs
+				cfg.VcsToken = response.Token
 				if err = c.setCredentials(ctx, cfg, appUsername, response.Token); err != nil {
 					logger.Warn().Err(err).Msg("failed to set git credentials")
 					return errors.Wrap(err, "failed to set git credentials")


### PR DESCRIPTION
If logging is set to DEBUG, when using Github App, access token and other details are displayed in logs during the token refresh process.

2025-08-28 18:08:14.2634:08PM INF refreshing github app token process=refresh-token
2025-08-28 18:08:14.4764:08PM DBG building command args=["config","--global","user.email","kubechecks@zapier.com"]
2025-08-28 18:08:14.4794:08PM DBG building command args=["config","--global","user.name","kubechecks"]
2025-08-28 18:08:14.4824:08PM DBG building command args=["https://x-access-token:foobar@github.com"]
2025-08-28 18:08:14.4834:08PM DBG building command args=["config","--global","credential.helper","store"]

fixes https://github.com/zapier/kubechecks/issues/456