### PR TITLE
chore: make rbac for argocd integration optional

### DIFF
--- a/charts/kubechecks/Chart.yaml
+++ b/charts/kubechecks/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: kubechecks
 description: A Helm chart for kubechecks
-version: 0.5.6
+version: 0.5.7
 type: application
 maintainers:
   - name: zapier

--- a/charts/kubechecks/templates/role.yaml
+++ b/charts/kubechecks/templates/role.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.argocd.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -13,3 +14,4 @@ rules:
       - get
       - list
       - watch
+{{ end }}

--- a/charts/kubechecks/templates/role.yaml
+++ b/charts/kubechecks/templates/role.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.argocd.create }}
+{{ if .Values.argocd.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/kubechecks/templates/rolebinding.yaml
+++ b/charts/kubechecks/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.argocd.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -11,3 +12,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "kubechecks.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/kubechecks/templates/rolebinding.yaml
+++ b/charts/kubechecks/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.argocd.create }}
+{{ if .Values.argocd.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -1,7 +1,13 @@
-# Labels to apply to all resources created by this Helm chart
+# ArgoCD integration configuration
+# Used to configure RBAC permissions for kubechecks to access ArgoCD resources
 argocd:
+  # Whether to create RBAC resources (Role/RoleBinding) for ArgoCD integration
+  create: true
+  # The namespace where ArgoCD is installed. kubechecks needs read access to
+  # ConfigMaps and Secrets in this namespace to integrate with ArgoCD
   namespace: argocd
 
+# Labels to apply to all resources created by this Helm chart
 commonLabels: {}
 
 configMap:

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -2,7 +2,9 @@
 # Used to configure RBAC permissions for kubechecks to access ArgoCD resources
 argocd:
   # Whether to create RBAC resources (Role/RoleBinding) for ArgoCD integration
-  create: true
+  rbac
+    create: true
+    
   # The namespace where ArgoCD is installed. kubechecks needs read access to
   # ConfigMaps and Secrets in this namespace to integrate with ArgoCD
   namespace: argocd

--- a/charts/kubechecks/values.yaml
+++ b/charts/kubechecks/values.yaml
@@ -2,7 +2,7 @@
 # Used to configure RBAC permissions for kubechecks to access ArgoCD resources
 argocd:
   # Whether to create RBAC resources (Role/RoleBinding) for ArgoCD integration
-  rbac
+  rbac:
     create: true
     
   # The namespace where ArgoCD is installed. kubechecks needs read access to


### PR DESCRIPTION
Problem statement: We are using ArgoCD to deploy applications with restrictions where no ArgoCD projects allows deployment of any resources in the `argocd` namespace. Therefore, I want to make this RBAC config as opt in,  so that I can deploy the chart as an ArgoCD application and deploy the required RBAC separately with ArgoCD manifests.

I'm open to getting your thoughts on this one. 
Also, there are no guidelines for contributions to Helm Chart, so happy to make any further changes that are required.