### PR TITLE
Use non-internal skip emoji

### DIFF
--- a/pkg/checks/kubeconform/validate.go
+++ b/pkg/checks/kubeconform/validate.go
@@ -106,7 +106,7 @@ func argoCdAppValidate(ctx context.Context, ctr container.Container, appName, ta
 		case validator.Empty:
 			// noop
 		case validator.Skipped:
-			outputString = append(outputString, fmt.Sprintf(" * :skip: Skipped: %s", sig))
+			outputString = append(outputString, fmt.Sprintf(" * :right_arrow: Skipped: %s", sig))
 		default:
 			outputString = append(outputString, fmt.Sprintf(" * :white_check_mark: Passed: %s", sig))
 		}


### PR DESCRIPTION
The :skip emoji isn't available in GitHub or GitLab, so let's swap it out for a equivalent that is publicly available.

<img width="733" height="192" alt="image" src="https://github.com/user-attachments/assets/52550dc7-3321-4c14-8cd1-51230dfa0649" />

Also happy to use a different emoji if a right arrow doesn't really convey the "skipped" intent. Just want something that is publicly available in both GitHub and GitLab.
