### PR TITLE
feat: add option to hide comments when no changes detected

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,10 @@ func init() {
 		newStringOpts().
 			withChoices("hide", "delete").
 			withDefault("hide"))
+	stringFlag(flags, "show-no-changes-comment", "Controls whether to post a comment when no changes are detected.",
+		newStringOpts().
+			withChoices("true", "false").
+			withDefault("true"))
 	stringSliceFlag(flags, "schemas-location", "Sets schema locations to be used for every check request. Can be a common path on the host or git urls in either git or http(s) format.")
 	boolFlag(flags, "enable-conftest", "Set to true to enable conftest policy checking of manifests.")
 	stringSliceFlag(flags, "policies-location", "Sets rego policy locations to be used for every check request. Can be common path inside the repos being checked or git urls in either git or http(s) format.",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,9 @@ func init() {
 		newStringOpts().
 			withChoices("hide", "delete").
 			withDefault("hide"))
+	boolFlag(flags, "show-no-changes-comment", "Controls whether to post a comment when no changes are detected.",
+		newBoolOpts().
+			withDefault(true))
 	stringSliceFlag(flags, "schemas-location", "Sets schema locations to be used for every check request. Can be a common path on the host or git urls in either git or http(s) format.")
 	boolFlag(flags, "enable-conftest", "Set to true to enable conftest policy checking of manifests.")
 	stringSliceFlag(flags, "policies-location", "Sets rego policy locations to be used for every check request. Can be common path inside the repos being checked or git urls in either git or http(s) format.",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,6 +80,7 @@ The full list of supported environment variables is described below:
 |`KUBECHECKS_REPO_REFRESH_INTERVAL`|Interval between static repo refreshes (for schemas and policies).|`5m`|
 |`KUBECHECKS_SCHEMAS_LOCATION`|Sets schema locations to be used for every check request. Can be a common path on the host or git urls in either git or http(s) format.|`[]`|
 |`KUBECHECKS_SHOW_DEBUG_INFO`|Set to true to print debug info to the footer of MR comments.|`false`|
+|`KUBECHECKS_SHOW_NO_CHANGES_COMMENT`|Controls whether to post a comment when no changes are detected.|`true`|
 |`KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE`|Sets the mode to use when tidying outdated comments. One of hide, delete.|`hide`|
 |`KUBECHECKS_VCS_BASE_URL`|VCS base url, useful if self hosting gitlab, enterprise github, etc.||
 |`KUBECHECKS_VCS_EMAIL`|VCS Email.||

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,6 +80,7 @@ The full list of supported environment variables is described below:
 |`KUBECHECKS_REPO_REFRESH_INTERVAL`|Interval between static repo refreshes (for schemas and policies).|`5m`|
 |`KUBECHECKS_SCHEMAS_LOCATION`|Sets schema locations to be used for every check request. Can be a common path on the host or git urls in either git or http(s) format.|`[]`|
 |`KUBECHECKS_SHOW_DEBUG_INFO`|Set to true to print debug info to the footer of MR comments.|`false`|
+|`KUBECHECKS_SHOW_NO_CHANGES_COMMENT`|Controls whether to post a comment when no changes are detected. One of true, false.|`true`|
 |`KUBECHECKS_TIDY_OUTDATED_COMMENTS_MODE`|Sets the mode to use when tidying outdated comments. One of hide, delete.|`hide`|
 |`KUBECHECKS_VCS_BASE_URL`|VCS base url, useful if self hosting gitlab, enterprise github, etc.||
 |`KUBECHECKS_VCS_EMAIL`|VCS Email.||

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,7 @@ type ServerConfig struct {
 	ArchiveCacheTTL          time.Duration `mapstructure:"archive-cache-ttl"`
 	SchemasLocations         []string      `mapstructure:"schemas-location"`
 	ShowDebugInfo            bool          `mapstructure:"show-debug-info"`
+	ShowNoChangesComment     bool          `mapstructure:"show-no-changes-comment"`
 	TidyOutdatedCommentsMode string        `mapstructure:"tidy-outdated-comments-mode"`
 	MaxQueueSize             int64         `mapstructure:"max-queue-size"`
 	MaxConcurrentChecks      int           `mapstructure:"max-concurrent-checks"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,6 +87,7 @@ type ServerConfig struct {
 	ArchiveCacheTTL          time.Duration `mapstructure:"archive-cache-ttl"`
 	SchemasLocations         []string      `mapstructure:"schemas-location"`
 	ShowDebugInfo            bool          `mapstructure:"show-debug-info"`
+	ShowNoChangesComment     bool          `mapstructure:"show-no-changes-comment"`
 	TidyOutdatedCommentsMode string        `mapstructure:"tidy-outdated-comments-mode"`
 	MaxQueueSize             int64         `mapstructure:"max-queue-size"`
 	MaxConcurrentChecks      int           `mapstructure:"max-concurrent-checks"`
@@ -125,6 +126,11 @@ func NewWithViper(v *viper.Viper) (ServerConfig, error) {
 			input := value.(string)
 			ns := strings.Split(input, ",")
 			return ns, nil
+		}
+
+		if in.String() == "string" && out.String() == "bool" {
+			input := value.(string)
+			return strings.ToLower(input) == "true", nil
 		}
 
 		return value, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -20,6 +20,7 @@ func TestNew(t *testing.T) {
 	v.Set("worst-conftest-state", "warning")
 	v.Set("repo-refresh-interval", "10m")
 	v.Set("additional-apps-namespaces", "default,kube-system")
+	v.Set("show-no-changes-comment", true)
 
 	cfg, err := NewWithViper(v)
 	require.NoError(t, err)
@@ -29,4 +30,5 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, pkg.StateWarning, cfg.WorstConfTestState, "worst states can be overridden")
 	assert.Equal(t, time.Minute*10, cfg.RepoRefreshInterval)
 	assert.Equal(t, []string{"default", "kube-system"}, cfg.AdditionalAppsNamespaces)
+	assert.True(t, cfg.ShowNoChangesComment)
 }

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -305,6 +305,8 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 			if _, err := ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf("## Kubechecks %s Report\nNo changes", ce.ctr.Config.Identifier)); err != nil {
 				return errors.Wrap(err, "failed to post no-changes report")
 			}
+		} else {
+			ce.logger.Debug().Msg("Skipping no-changes comment (show-no-changes-comment=false)")
 		}
 		return nil
 	}

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -301,8 +301,10 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 
 	if len(ce.affectedItems.Applications) <= 0 && len(ce.affectedItems.ApplicationSets) <= 0 {
 		ce.logger.Info().Msg("No affected apps or appsets, skipping")
-		if _, err := ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf("## Kubechecks %s Report\nNo changes", ce.ctr.Config.Identifier)); err != nil {
-			return errors.Wrap(err, "failed to post changes")
+		if ce.ctr.Config.ShowNoChangesComment {
+			if _, err := ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf("## Kubechecks %s Report\nNo changes", ce.ctr.Config.Identifier)); err != nil {
+				return errors.Wrap(err, "failed to post changes")
+			}
 		}
 		return nil
 	}

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -303,7 +303,7 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 		ce.logger.Info().Msg("No affected apps or appsets, skipping")
 		if ce.ctr.Config.ShowNoChangesComment {
 			if _, err := ce.ctr.VcsClient.PostMessage(ctx, ce.pullRequest, fmt.Sprintf("## Kubechecks %s Report\nNo changes", ce.ctr.Config.Identifier)); err != nil {
-				return errors.Wrap(err, "failed to post changes")
+				return errors.Wrap(err, "failed to post no-changes report")
 			}
 		}
 		return nil


### PR DESCRIPTION
Adds KUBECHECKS_SHOW_NO_CHANGES_COMMENT env var to control whether kubechecks posts a comment when no affected apps are found.

Closes issue #466