### PR TITLE
fix: github archive download race condition

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -7,3 +7,4 @@ kubeconform 0.7.0
 kustomize 5.8.0
 mockery 3.3.4
 tilt 0.33.2
+python 3.14.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,4 +7,4 @@ kubeconform 0.7.0
 kustomize 5.8.0
 mockery 3.3.4
 tilt 0.33.2
-python 3.11.10
+

--- a/.tool-versions
+++ b/.tool-versions
@@ -7,4 +7,4 @@ kubeconform 0.7.0
 kustomize 5.8.0
 mockery 3.3.4
 tilt 0.33.2
-python 3.14.3
+python 3.11.10

--- a/pkg/vcs/github_client/archive.go
+++ b/pkg/vcs/github_client/archive.go
@@ -1,0 +1,149 @@
+package github_client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+
+	"github.com/zapier/kubechecks/pkg/vcs"
+)
+
+// DownloadArchive returns the archive URL for downloading a repository at a specific commit
+func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (string, error) {
+	ctx, span := tracer.Start(ctx, "DownloadArchive")
+	defer span.End()
+
+	// Retry configuration for waiting on GitHub to compute merge commit SHA
+	rc := c.archiveRetry.withDefaults(10, 1*time.Second, 16*time.Second)
+
+	var ghPR *github.PullRequest
+	var err error
+	backoff := rc.initialBackoff
+
+	// Retry loop: GitHub needs time to compute merge_commit_sha after PR creation/update
+	for attempt := 0; attempt <= rc.maxRetries; attempt++ {
+		// Get PR details to find merge_commit_sha
+		ghPR, _, err = c.googleClient.PullRequests.Get(ctx, pr.Owner, pr.Name, pr.CheckID)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to get PR details")
+		}
+
+		// CRITICAL: Validate that GitHub has processed the latest commit
+		// When a new commit is pushed, GitHub may return outdated merge_commit_sha from the previous commit.
+		// We must verify:
+		// 1. HEAD SHA matches the expected SHA from the webhook
+		// 2. Merge commit SHA is available (non-empty)
+		// 3. Mergeable is non-nil (GitHub has finished recomputing the merge)
+		//    When Mergeable is nil, GitHub is still processing - merge_commit_sha may be STALE
+		//    from the previous HEAD, even though head.sha already reflects the new commit.
+		headSHAMatches := ghPR.Head != nil && ghPR.Head.SHA != nil && *ghPR.Head.SHA == pr.SHA
+		mergeCommitAvailable := ghPR.MergeCommitSHA != nil && *ghPR.MergeCommitSHA != ""
+		mergeComputed := ghPR.Mergeable != nil // nil means GitHub is still computing
+
+		if headSHAMatches && mergeCommitAvailable && mergeComputed {
+			// Success - merge commit SHA is ready AND corresponds to the current HEAD
+			log.Debug().
+				Caller().
+				Str("repo", pr.FullName).
+				Int("pr_number", pr.CheckID).
+				Str("head_sha", pr.SHA).
+				Str("merge_commit_sha", *ghPR.MergeCommitSHA).
+				Bool("mergeable", *ghPR.Mergeable).
+				Msg("merge commit SHA is current and ready")
+			break
+		}
+
+		// If GitHub has finished computing and determined the PR is not mergeable
+		// for the current HEAD, short-circuit instead of waiting through all backoff intervals.
+		// We require headSHAMatches because if the API is still serving stale PR data,
+		// Mergeable reflects the previous commit and may flip once the API catches up.
+		if headSHAMatches && mergeComputed && !*ghPR.Mergeable {
+			log.Warn().
+				Caller().
+				Str("repo", pr.FullName).
+				Int("pr_number", pr.CheckID).
+				Str("head_sha", pr.SHA).
+				Msg("PR is not mergeable (has conflicts); stopping retries")
+			return "", errors.New("PR is not mergeable (has conflicts)")
+		}
+
+		// If this is the last attempt, fail with detailed info
+		if attempt == rc.maxRetries {
+			var reason string
+			if !headSHAMatches {
+				apiHeadSHA := "nil"
+				if ghPR.Head != nil && ghPR.Head.SHA != nil {
+					apiHeadSHA = *ghPR.Head.SHA
+				}
+				reason = fmt.Sprintf("HEAD SHA mismatch (expected: %s, got: %s)", pr.SHA, apiHeadSHA)
+			} else if !mergeComputed {
+				reason = "GitHub still computing merge status (mergeable is nil)"
+			} else if !mergeCommitAvailable {
+				reason = "merge commit SHA not available"
+			}
+
+			log.Warn().
+				Caller().
+				Str("repo", pr.FullName).
+				Int("pr_number", pr.CheckID).
+				Int("attempts", attempt+1).
+				Str("reason", reason).
+				Msg("failed to get current merge commit SHA after retries")
+			return "", fmt.Errorf("PR merge commit SHA not ready (may have conflicts or GitHub still processing): %s", reason)
+		}
+
+		// Wait before retrying (exponential backoff)
+		log.Debug().
+			Caller().
+			Str("repo", pr.FullName).
+			Int("pr_number", pr.CheckID).
+			Int("attempt", attempt+1).
+			Dur("backoff", backoff).
+			Bool("head_sha_matches", headSHAMatches).
+			Bool("merge_commit_available", mergeCommitAvailable).
+			Bool("merge_computed", mergeComputed).
+			Msg("merge commit SHA not yet current, retrying...")
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(backoff):
+			// Exponential backoff with cap
+			backoff *= 2
+			if backoff > rc.maxBackoff {
+				backoff = rc.maxBackoff
+			}
+		}
+	}
+
+	mergeCommitSHA := *ghPR.MergeCommitSHA
+
+	// Construct archive URL
+	// Format: https://github.com/{owner}/{repo}/archive/{sha}.zip
+	// Or for enterprise: https://{base_url}/{owner}/{repo}/archive/{sha}.zip
+	var archiveURL string
+	if c.cfg.VcsBaseUrl != "" {
+		// GitHub Enterprise
+		baseURL := strings.TrimSuffix(c.cfg.VcsBaseUrl, "/api/v3")
+		baseURL = strings.TrimSuffix(baseURL, "/")
+		archiveURL = fmt.Sprintf("%s/%s/%s/archive/%s.zip", baseURL, pr.Owner, pr.Name, mergeCommitSHA)
+	} else {
+		// GitHub.com
+		archiveURL = fmt.Sprintf("https://github.com/%s/%s/archive/%s.zip", pr.Owner, pr.Name, mergeCommitSHA)
+	}
+
+	log.Debug().
+		Caller().
+		Str("repo", pr.FullName).
+		Int("pr_number", pr.CheckID).
+		Str("merge_commit_sha", mergeCommitSHA).
+		Str("archive_url", archiveURL).
+		Msg("generated archive URL")
+
+	return archiveURL, nil
+}

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -556,9 +556,11 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 			break
 		}
 
-		// If GitHub has finished computing and determined the PR is not mergeable,
-		// short-circuit instead of waiting through all backoff intervals.
-		if mergeComputed && !*ghPR.Mergeable {
+		// If GitHub has finished computing and determined the PR is not mergeable
+		// for the current HEAD, short-circuit instead of waiting through all backoff intervals.
+		// We require headSHAMatches because if the API is still serving stale PR data,
+		// Mergeable reflects the previous commit and may flip once the API catches up.
+		if headSHAMatches && mergeComputed && !*ghPR.Mergeable {
 			log.Warn().
 				Caller().
 				Str("repo", pr.FullName).

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -26,10 +26,34 @@ import (
 
 var tracer = otel.Tracer("pkg/vcs/github_client")
 
+// retryConfig holds retry/backoff parameters for polling loops.
+// Zero values mean "use defaults".
+type retryConfig struct {
+	maxRetries     int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+}
+
+func (r retryConfig) withDefaults(maxRetries int, initialBackoff, maxBackoff time.Duration) retryConfig {
+	if r.maxRetries == 0 {
+		r.maxRetries = maxRetries
+	}
+	if r.initialBackoff == 0 {
+		r.initialBackoff = initialBackoff
+	}
+	if r.maxBackoff == 0 {
+		r.maxBackoff = maxBackoff
+	}
+	return r
+}
+
 type Client struct {
 	shurcoolClient *githubv4.Client
 	googleClient   *GClient
 	cfg            config.ServerConfig
+
+	// archiveRetry overrides retry parameters for DownloadArchive. Zero value uses defaults.
+	archiveRetry retryConfig
 
 	username, email string
 }
@@ -490,18 +514,14 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 	defer span.End()
 
 	// Retry configuration for waiting on GitHub to compute merge commit SHA
-	const (
-		maxRetries     = 10
-		initialBackoff = 1 * time.Second
-		maxBackoff     = 16 * time.Second
-	)
+	rc := c.archiveRetry.withDefaults(10, 1*time.Second, 16*time.Second)
 
 	var ghPR *github.PullRequest
 	var err error
-	backoff := initialBackoff
+	backoff := rc.initialBackoff
 
 	// Retry loop: GitHub needs time to compute merge_commit_sha after PR creation/update
-	for attempt := 0; attempt <= maxRetries; attempt++ {
+	for attempt := 0; attempt <= rc.maxRetries; attempt++ {
 		// Get PR details to find merge_commit_sha
 		ghPR, _, err = c.googleClient.PullRequests.Get(ctx, pr.Owner, pr.Name, pr.CheckID)
 		if err != nil {
@@ -546,7 +566,7 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 		}
 
 		// If this is the last attempt, fail with detailed info
-		if attempt == maxRetries {
+		if attempt == rc.maxRetries {
 			var reason string
 			if !headSHAMatches {
 				apiHeadSHA := "nil"
@@ -588,8 +608,8 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 		case <-time.After(backoff):
 			// Exponential backoff with cap
 			backoff *= 2
-			if backoff > maxBackoff {
-				backoff = maxBackoff
+			if backoff > rc.maxBackoff {
+				backoff = rc.maxBackoff
 			}
 		}
 	}

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -3,12 +3,8 @@ package github_client
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
-	"regexp"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	giturls "github.com/chainguard-dev/git-urls"
@@ -19,33 +15,11 @@ import (
 	"go.opentelemetry.io/otel"
 	"golang.org/x/oauth2"
 
-	"github.com/zapier/kubechecks/pkg"
 	"github.com/zapier/kubechecks/pkg/config"
 	"github.com/zapier/kubechecks/pkg/vcs"
 )
 
 var tracer = otel.Tracer("pkg/vcs/github_client")
-
-// retryConfig holds retry/backoff parameters for polling loops.
-// Zero values mean "use defaults".
-type retryConfig struct {
-	maxRetries     int
-	initialBackoff time.Duration
-	maxBackoff     time.Duration
-}
-
-func (r retryConfig) withDefaults(maxRetries int, initialBackoff, maxBackoff time.Duration) retryConfig {
-	if r.maxRetries == 0 {
-		r.maxRetries = maxRetries
-	}
-	if r.initialBackoff == 0 {
-		r.initialBackoff = initialBackoff
-	}
-	if r.maxBackoff == 0 {
-		r.maxBackoff = maxBackoff
-	}
-	return r
-}
 
 type Client struct {
 	shurcoolClient *githubv4.Client
@@ -180,54 +154,7 @@ func (c *Client) GetAuthHeaders() map[string]string {
 	}
 }
 
-func (c *Client) VerifyHook(r *http.Request, secret string) ([]byte, error) {
-	// GitHub provides the SHA256 of the secret + payload body, so we extract the body and compare
-	// We have to split it like this as the ValidatePayload method consumes the request
-	if secret != "" {
-		return github.ValidatePayload(r, []byte(secret))
-	} else {
-		// No secret provided, so we just grab the body
-		return io.ReadAll(r.Body)
-	}
-}
-
 var nilPr vcs.PullRequest
-
-func (c *Client) ParseHook(ctx context.Context, r *http.Request, request []byte) (vcs.PullRequest, error) {
-	payload, err := github.ParseWebHook(github.WebHookType(r), request)
-	if err != nil {
-		return nilPr, err
-	}
-
-	switch p := payload.(type) {
-	case *github.PullRequestEvent:
-		switch p.GetAction() {
-		case "opened", "synchronize", "reopened", "edited":
-			log.Info().Str("action", p.GetAction()).Msg("handling Github event from PR")
-			return c.buildRepoFromEvent(p), nil
-		default:
-			log.Info().Str("action", p.GetAction()).Msg("ignoring Github pull request event due to non commit based action")
-			return nilPr, vcs.ErrInvalidType
-		}
-	case *github.IssueCommentEvent:
-		switch p.GetAction() {
-		case "created":
-			if strings.ToLower(p.Comment.GetBody()) == c.cfg.ReplanCommentMessage {
-				log.Info().Msgf("Got %s comment, Running again", c.cfg.ReplanCommentMessage)
-				return c.buildRepoFromComment(ctx, p)
-			} else {
-				log.Info().Str("action", p.GetAction()).Msg("ignoring Github issue comment event due to non matching string")
-				return nilPr, vcs.ErrInvalidType
-			}
-		default:
-			log.Info().Str("action", p.GetAction()).Msg("ignoring Github issue comment due to invalid action")
-			return nilPr, vcs.ErrInvalidType
-		}
-	default:
-		log.Error().Msg("invalid event provided to Github client")
-		return nilPr, vcs.ErrInvalidType
-	}
-}
 
 func (c *Client) buildRepo(pullRequest *github.PullRequest) vcs.PullRequest {
 	repo := pullRequest.Head.Repo
@@ -274,38 +201,6 @@ func (c *Client) buildRepoFromComment(context context.Context, comment *github.I
 	return c.buildRepo(pr), nil
 }
 
-func toGithubCommitStatus(state pkg.CommitState) *string {
-	switch state {
-	case pkg.StateError, pkg.StatePanic:
-		return pkg.Pointer("error")
-	case pkg.StateFailure:
-		return pkg.Pointer("failure")
-	case pkg.StateRunning:
-		return pkg.Pointer("pending")
-	case pkg.StateSuccess, pkg.StateWarning, pkg.StateNone, pkg.StateSkip:
-		return pkg.Pointer("success")
-	}
-
-	log.Warn().Str("state", state.BareString()).Msg("failed to convert to a github commit status")
-	return pkg.Pointer("failure")
-}
-
-func (c *Client) CommitStatus(ctx context.Context, pr vcs.PullRequest, status pkg.CommitState) error {
-	log.Info().Str("repo", pr.Name).Str("sha", pr.SHA).Str("status", status.BareString()).Msg("setting Github commit status")
-	repoStatus, _, err := c.googleClient.Repositories.CreateStatus(ctx, pr.Owner, pr.Name, pr.SHA, &github.RepoStatus{
-		State:       toGithubCommitStatus(status),
-		Description: pkg.Pointer(status.BareString()),
-		ID:          pkg.Pointer(int64(pr.CheckID)),
-		Context:     pkg.Pointer("kubechecks"),
-	})
-	if err != nil {
-		log.Err(err).Msg("could not set Github commit status")
-		return err
-	}
-	log.Debug().Caller().Interface("status", repoStatus).Msg("Github commit status set")
-	return nil
-}
-
 func parseRepo(cloneUrl string) (string, string) {
 	result, err := giturls.Parse(cloneUrl)
 	if err != nil {
@@ -323,138 +218,6 @@ func parseRepo(cloneUrl string) (string, string) {
 	owner := parts[0]
 	repoName := strings.TrimSuffix(parts[1], ".git")
 	return owner, repoName
-}
-
-func (c *Client) GetHookByUrl(ctx context.Context, ownerAndRepoName, webhookUrl string) (*vcs.WebHookConfig, error) {
-	owner, repoName := parseRepo(ownerAndRepoName)
-	items, _, err := c.googleClient.Repositories.ListHooks(ctx, owner, repoName, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to list hooks")
-	}
-
-	for _, item := range items {
-		itemConfig := item.GetConfig()
-		// check if the hook's config has a URL
-		hookPayloadURL := ""
-		if itemConfig != nil {
-			hookPayloadURL = itemConfig.GetURL()
-		}
-		if hookPayloadURL == webhookUrl {
-			return &vcs.WebHookConfig{
-				Url:    hookPayloadURL,
-				Events: item.Events, // TODO: translate GH specific event names to VCS agnostic
-			}, nil
-		}
-	}
-
-	return nil, vcs.ErrHookNotFound
-}
-
-func (c *Client) CreateHook(ctx context.Context, ownerAndRepoName, webhookUrl, webhookSecret string) error {
-	owner, repoName := parseRepo(ownerAndRepoName)
-	_, resp, err := c.googleClient.Repositories.CreateHook(ctx, owner, repoName, &github.Hook{
-		Active: pkg.Pointer(true),
-		Config: &github.HookConfig{
-			ContentType: pkg.Pointer("json"),
-			InsecureSSL: pkg.Pointer("0"),
-			URL:         pkg.Pointer(webhookUrl),
-			Secret:      pkg.Pointer(webhookSecret),
-		},
-		Events: []string{
-			"pull_request", "issue_comment",
-		},
-		Name: pkg.Pointer("web"),
-	})
-	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		statusCode := 0
-		if resp != nil {
-			statusCode = resp.StatusCode
-		}
-		return errors.Wrap(err, fmt.Sprintf("failed to create hook, statuscode: %d", statusCode))
-	}
-	return nil
-}
-
-var rePullRequest = regexp.MustCompile(`(.*)/(.*)#(\d+)`)
-
-func (c *Client) LoadHook(ctx context.Context, id string) (vcs.PullRequest, error) {
-	m := rePullRequest.FindStringSubmatch(id)
-	if len(m) != 4 {
-		return nilPr, errors.New("must be in format OWNER/REPO#PR")
-	}
-
-	ownerName := m[1]
-	repoName := m[2]
-	prNumber, err := strconv.ParseInt(m[3], 10, 32)
-	if err != nil {
-		return nilPr, errors.Wrap(err, "failed to parse int")
-	}
-
-	repoInfo, _, err := c.googleClient.Repositories.Get(ctx, ownerName, repoName)
-	if err != nil {
-		return nilPr, errors.Wrap(err, "failed to get repo")
-	}
-
-	pullRequest, _, err := c.googleClient.PullRequests.Get(ctx, ownerName, repoName, int(prNumber))
-	if err != nil {
-		return nilPr, errors.Wrap(err, "failed to get pull request")
-	}
-
-	var labels []string
-	for _, label := range pullRequest.Labels {
-		labels = append(labels, label.GetName())
-	}
-
-	var (
-		baseRef                    string
-		headRef, headSha           string
-		login, userName, userEmail string
-	)
-
-	if pullRequest.Base != nil {
-		baseRef = unPtr(pullRequest.Base.Ref)
-		headRef = unPtr(pullRequest.Head.Ref)
-	}
-
-	if repoInfo.Owner != nil {
-		login = unPtr(repoInfo.Owner.Login)
-	} else {
-		login = "kubechecks"
-	}
-
-	if pullRequest.Head != nil {
-		headSha = unPtr(pullRequest.Head.SHA)
-	}
-
-	if pullRequest.User != nil {
-		userName = unPtr(pullRequest.User.Name)
-		userEmail = unPtr(pullRequest.User.Email)
-	}
-
-	// these are required for `git merge` later on
-	if userName == "" {
-		userName = "kubechecks"
-	}
-	if userEmail == "" {
-		userEmail = "kubechecks@github.com"
-	}
-
-	return vcs.PullRequest{
-		BaseRef:       baseRef,
-		HeadRef:       headRef,
-		DefaultBranch: unPtr(repoInfo.DefaultBranch),
-		CloneURL:      unPtr(repoInfo.CloneURL),
-		FullName:      repoInfo.GetFullName(),
-		Owner:         login,
-		Name:          repoInfo.GetName(),
-		CheckID:       int(prNumber),
-		SHA:           headSha,
-		Username:      userName,
-		Email:         userEmail,
-		Labels:        labels,
-
-		Config: c.cfg,
-	}, nil
 }
 
 func unPtr[T interface{ string | int }](ps *T) T {
@@ -506,156 +269,4 @@ func (c *Client) GetPullRequestFiles(ctx context.Context, pr vcs.PullRequest) ([
 		Msg("fetched PR files from GitHub API")
 
 	return allFiles, nil
-}
-
-// DownloadArchive returns the archive URL for downloading a repository at a specific commit
-func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (string, error) {
-	ctx, span := tracer.Start(ctx, "DownloadArchive")
-	defer span.End()
-
-	// Retry configuration for waiting on GitHub to compute merge commit SHA
-	rc := c.archiveRetry.withDefaults(10, 1*time.Second, 16*time.Second)
-
-	// Validate and normalize retry configuration to avoid unexpected loop behavior or panics.
-	if rc.maxRetries < 0 {
-		rc.maxRetries = 0
-	}
-	if rc.initialBackoff <= 0 {
-		rc.initialBackoff = 1 * time.Second
-	}
-	if rc.maxBackoff <= 0 {
-		rc.maxBackoff = 16 * time.Second
-	}
-	if rc.maxBackoff < rc.initialBackoff {
-		rc.maxBackoff = rc.initialBackoff
-	}
-
-	var ghPR *github.PullRequest
-	var err error
-	backoff := rc.initialBackoff
-	if backoff > rc.maxBackoff {
-		backoff = rc.maxBackoff
-	}
-
-	// Retry loop: GitHub needs time to compute merge_commit_sha after PR creation/update
-	for attempt := 0; attempt <= rc.maxRetries; attempt++ {
-		// Get PR details to find merge_commit_sha
-		ghPR, _, err = c.googleClient.PullRequests.Get(ctx, pr.Owner, pr.Name, pr.CheckID)
-		if err != nil {
-			return "", errors.Wrap(err, "failed to get PR details")
-		}
-
-		// CRITICAL: Validate that GitHub has processed the latest commit
-		// When a new commit is pushed, GitHub may return outdated merge_commit_sha from the previous commit.
-		// We must verify:
-		// 1. HEAD SHA matches the expected SHA from the webhook
-		// 2. Merge commit SHA is available (non-empty)
-		// 3. Mergeable is non-nil (GitHub has finished recomputing the merge)
-		//    When Mergeable is nil, GitHub is still processing - merge_commit_sha may be STALE
-		//    from the previous HEAD, even though head.sha already reflects the new commit.
-		headSHAMatches := ghPR.Head != nil && ghPR.Head.SHA != nil && *ghPR.Head.SHA == pr.SHA
-		mergeCommitAvailable := ghPR.MergeCommitSHA != nil && *ghPR.MergeCommitSHA != ""
-		mergeComputed := ghPR.Mergeable != nil // nil means GitHub is still computing
-
-		if headSHAMatches && mergeCommitAvailable && mergeComputed {
-			// Success - merge commit SHA is ready AND corresponds to the current HEAD
-			log.Debug().
-				Caller().
-				Str("repo", pr.FullName).
-				Int("pr_number", pr.CheckID).
-				Str("head_sha", pr.SHA).
-				Str("merge_commit_sha", *ghPR.MergeCommitSHA).
-				Bool("mergeable", *ghPR.Mergeable).
-				Msg("merge commit SHA is current and ready")
-			break
-		}
-
-		// If GitHub has finished computing and determined the PR is not mergeable
-		// for the current HEAD, short-circuit instead of waiting through all backoff intervals.
-		// We require headSHAMatches because if the API is still serving stale PR data,
-		// Mergeable reflects the previous commit and may flip once the API catches up.
-		if headSHAMatches && mergeComputed && !*ghPR.Mergeable {
-			log.Warn().
-				Caller().
-				Str("repo", pr.FullName).
-				Int("pr_number", pr.CheckID).
-				Str("head_sha", pr.SHA).
-				Msg("PR is not mergeable (has conflicts); stopping retries")
-			return "", errors.New("PR is not mergeable (has conflicts)")
-		}
-
-		// If this is the last attempt, fail with detailed info
-		if attempt == rc.maxRetries {
-			var reason string
-			if !headSHAMatches {
-				apiHeadSHA := "nil"
-				if ghPR.Head != nil && ghPR.Head.SHA != nil {
-					apiHeadSHA = *ghPR.Head.SHA
-				}
-				reason = fmt.Sprintf("HEAD SHA mismatch (expected: %s, got: %s)", pr.SHA, apiHeadSHA)
-			} else if !mergeComputed {
-				reason = "GitHub still computing merge status (mergeable is nil)"
-			} else if !mergeCommitAvailable {
-				reason = "merge commit SHA not available"
-			}
-
-			log.Warn().
-				Caller().
-				Str("repo", pr.FullName).
-				Int("pr_number", pr.CheckID).
-				Int("attempts", attempt+1).
-				Str("reason", reason).
-				Msg("failed to get current merge commit SHA after retries")
-			return "", fmt.Errorf("PR merge commit SHA not ready (may have conflicts or GitHub still processing): %s", reason)
-		}
-
-		// Wait before retrying (exponential backoff)
-		log.Debug().
-			Caller().
-			Str("repo", pr.FullName).
-			Int("pr_number", pr.CheckID).
-			Int("attempt", attempt+1).
-			Dur("backoff", backoff).
-			Bool("head_sha_matches", headSHAMatches).
-			Bool("merge_commit_available", mergeCommitAvailable).
-			Bool("merge_computed", mergeComputed).
-			Msg("merge commit SHA not yet current, retrying...")
-
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(backoff):
-			// Exponential backoff with cap
-			backoff *= 2
-			if backoff > rc.maxBackoff {
-				backoff = rc.maxBackoff
-			}
-		}
-	}
-
-	mergeCommitSHA := *ghPR.MergeCommitSHA
-
-	// Construct archive URL
-	// Format: https://github.com/{owner}/{repo}/archive/{sha}.zip
-	// Or for enterprise: https://{base_url}/{owner}/{repo}/archive/{sha}.zip
-	var archiveURL string
-	if c.cfg.VcsBaseUrl != "" {
-		// GitHub Enterprise
-		baseURL := strings.TrimSuffix(c.cfg.VcsBaseUrl, "/api/v3")
-		baseURL = strings.TrimSuffix(baseURL, "/")
-		archiveURL = fmt.Sprintf("%s/%s/%s/archive/%s.zip", baseURL, pr.Owner, pr.Name, mergeCommitSHA)
-	} else {
-		// GitHub.com
-		archiveURL = fmt.Sprintf("https://github.com/%s/%s/archive/%s.zip", pr.Owner, pr.Name, mergeCommitSHA)
-	}
-
-	log.Debug().
-		Caller().
-		Str("repo", pr.FullName).
-		Int("pr_number", pr.CheckID).
-		Str("merge_commit_sha", mergeCommitSHA).
-		Str("archive_url", archiveURL).
-		Msg("generated archive URL")
-
-	return archiveURL, nil
 }

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -491,9 +491,9 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 
 	// Retry configuration for waiting on GitHub to compute merge commit SHA
 	const (
-		maxRetries     = 5
-		initialBackoff = 500 * time.Millisecond
-		maxBackoff     = 8 * time.Second
+		maxRetries     = 10
+		initialBackoff = 1 * time.Second
+		maxBackoff     = 16 * time.Second
 	)
 
 	var ghPR *github.PullRequest
@@ -509,12 +509,18 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 		}
 
 		// CRITICAL: Validate that GitHub has processed the latest commit
-		// When a new commit is pushed, GitHub may return outdated merge_commit_sha from the previous commit
-		// We must verify that the HEAD SHA matches the expected SHA from the webhook
+		// When a new commit is pushed, GitHub may return outdated merge_commit_sha from the previous commit.
+		// We must verify:
+		// 1. HEAD SHA matches the expected SHA from the webhook
+		// 2. Merge commit SHA is available (non-empty)
+		// 3. Mergeable is non-nil (GitHub has finished recomputing the merge)
+		//    When Mergeable is nil, GitHub is still processing - merge_commit_sha may be STALE
+		//    from the previous HEAD, even though head.sha already reflects the new commit.
 		headSHAMatches := ghPR.Head != nil && ghPR.Head.SHA != nil && *ghPR.Head.SHA == pr.SHA
 		mergeCommitAvailable := ghPR.MergeCommitSHA != nil && *ghPR.MergeCommitSHA != ""
+		mergeComputed := ghPR.Mergeable != nil // nil means GitHub is still computing
 
-		if headSHAMatches && mergeCommitAvailable {
+		if headSHAMatches && mergeCommitAvailable && mergeComputed {
 			// Success - merge commit SHA is ready AND corresponds to the current HEAD
 			log.Debug().
 				Caller().
@@ -522,6 +528,7 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 				Int("pr_number", pr.CheckID).
 				Str("head_sha", pr.SHA).
 				Str("merge_commit_sha", *ghPR.MergeCommitSHA).
+				Bool("mergeable", *ghPR.Mergeable).
 				Msg("merge commit SHA is current and ready")
 			break
 		}
@@ -535,6 +542,8 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 					apiHeadSHA = *ghPR.Head.SHA
 				}
 				reason = fmt.Sprintf("HEAD SHA mismatch (expected: %s, got: %s)", pr.SHA, apiHeadSHA)
+			} else if !mergeComputed {
+				reason = "GitHub still computing merge status (mergeable is nil)"
 			} else if !mergeCommitAvailable {
 				reason = "merge commit SHA not available"
 			}
@@ -558,6 +567,7 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 			Dur("backoff", backoff).
 			Bool("head_sha_matches", headSHAMatches).
 			Bool("merge_commit_available", mergeCommitAvailable).
+			Bool("merge_computed", mergeComputed).
 			Msg("merge commit SHA not yet current, retrying...")
 
 		select {

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -519,6 +519,9 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 	var ghPR *github.PullRequest
 	var err error
 	backoff := rc.initialBackoff
+	if backoff > rc.maxBackoff {
+		backoff = rc.maxBackoff
+	}
 
 	// Retry loop: GitHub needs time to compute merge_commit_sha after PR creation/update
 	for attempt := 0; attempt <= rc.maxRetries; attempt++ {

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -533,6 +533,18 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 			break
 		}
 
+		// If GitHub has finished computing and determined the PR is not mergeable,
+		// short-circuit instead of waiting through all backoff intervals.
+		if mergeComputed && !*ghPR.Mergeable {
+			log.Warn().
+				Caller().
+				Str("repo", pr.FullName).
+				Int("pr_number", pr.CheckID).
+				Str("head_sha", pr.SHA).
+				Msg("PR is not mergeable (has conflicts); stopping retries")
+			return "", errors.New("PR is not mergeable (has conflicts)")
+		}
+
 		// If this is the last attempt, fail with detailed info
 		if attempt == maxRetries {
 			var reason string
@@ -580,11 +592,6 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 				backoff = maxBackoff
 			}
 		}
-	}
-
-	// Check if PR is mergeable
-	if ghPR.Mergeable != nil && !*ghPR.Mergeable {
-		return "", errors.New("PR is not mergeable (has conflicts)")
 	}
 
 	mergeCommitSHA := *ghPR.MergeCommitSHA

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -516,6 +516,20 @@ func (c *Client) DownloadArchive(ctx context.Context, pr vcs.PullRequest) (strin
 	// Retry configuration for waiting on GitHub to compute merge commit SHA
 	rc := c.archiveRetry.withDefaults(10, 1*time.Second, 16*time.Second)
 
+	// Validate and normalize retry configuration to avoid unexpected loop behavior or panics.
+	if rc.maxRetries < 0 {
+		rc.maxRetries = 0
+	}
+	if rc.initialBackoff <= 0 {
+		rc.initialBackoff = 1 * time.Second
+	}
+	if rc.maxBackoff <= 0 {
+		rc.maxBackoff = 16 * time.Second
+	}
+	if rc.maxBackoff < rc.initialBackoff {
+		rc.maxBackoff = rc.initialBackoff
+	}
+
 	var ghPR *github.PullRequest
 	var err error
 	backoff := rc.initialBackoff

--- a/pkg/vcs/github_client/client_test.go
+++ b/pkg/vcs/github_client/client_test.go
@@ -1051,6 +1051,7 @@ func TestClient_DownloadArchive_GHEnterprise(t *testing.T) {
 	url, err := c.DownloadArchive(context.Background(), pr)
 	require.NoError(t, err)
 	assert.Equal(t, "https://github.example.com/myorg/myrepo/archive/merge-sha.zip", url)
+	mockPR.AssertExpectations(t)
 }
 
 // --- test helpers ---

--- a/pkg/vcs/github_client/client_test.go
+++ b/pkg/vcs/github_client/client_test.go
@@ -885,3 +885,195 @@ func TestParseRepo_InvalidPath(t *testing.T) {
 		parseRepo("https://github.com/invalid")
 	})
 }
+
+func TestClient_DownloadArchive_HappyPath(t *testing.T) {
+	// GitHub returns a fully ready PR on the first call:
+	// head SHA matches, merge_commit_sha present, mergeable is non-nil.
+	mockPR := NewMockPullRequestsServicesWithGet(t,
+		prResponse{
+			headSHA:        "new-sha",
+			mergeCommitSHA: "merge-abc123",
+			mergeable:      github.Ptr(true),
+		},
+	)
+
+	c := &Client{
+		googleClient: &GClient{PullRequests: mockPR},
+	}
+
+	pr := vcs.PullRequest{
+		Owner:    "owner",
+		Name:     "repo",
+		FullName: "owner/repo",
+		CheckID:  42,
+		SHA:      "new-sha",
+	}
+
+	url, err := c.DownloadArchive(context.Background(), pr)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/owner/repo/archive/merge-abc123.zip", url)
+	mockPR.AssertExpectations(t)
+}
+
+func TestClient_DownloadArchive_StaleMergeCommitThenReady(t *testing.T) {
+	// Simulates the race condition: a new commit is pushed, GitHub updates
+	// head.sha immediately but merge_commit_sha is stale (from old merge)
+	// and Mergeable is nil while GitHub recomputes.
+	// First call: head SHA matches, stale merge_commit_sha present, Mergeable nil.
+	// Second call: head SHA matches, new merge_commit_sha, Mergeable non-nil.
+	mockPR := NewMockPullRequestsServicesWithGet(t,
+		prResponse{
+			headSHA:        "new-sha",
+			mergeCommitSHA: "stale-old-merge",
+			mergeable:      nil, // still computing
+		},
+		prResponse{
+			headSHA:        "new-sha",
+			mergeCommitSHA: "fresh-new-merge",
+			mergeable:      github.Ptr(true),
+		},
+	)
+
+	c := &Client{
+		googleClient: &GClient{PullRequests: mockPR},
+	}
+
+	pr := vcs.PullRequest{
+		Owner:    "owner",
+		Name:     "repo",
+		FullName: "owner/repo",
+		CheckID:  42,
+		SHA:      "new-sha",
+	}
+
+	url, err := c.DownloadArchive(context.Background(), pr)
+	require.NoError(t, err)
+	// Must use the fresh merge SHA, not the stale one
+	assert.Equal(t, "https://github.com/owner/repo/archive/fresh-new-merge.zip", url)
+	assert.NotContains(t, url, "stale-old-merge")
+	mockPR.AssertExpectations(t)
+}
+
+func TestClient_DownloadArchive_NotMergeable(t *testing.T) {
+	// GitHub has finished computing and the PR has conflicts.
+	// Should short-circuit immediately without retrying.
+	mockPR := NewMockPullRequestsServicesWithGet(t,
+		prResponse{
+			headSHA:        "new-sha",
+			mergeCommitSHA: "", // no merge commit when conflicts exist
+			mergeable:      github.Ptr(false),
+		},
+	)
+
+	c := &Client{
+		googleClient: &GClient{PullRequests: mockPR},
+	}
+
+	pr := vcs.PullRequest{
+		Owner:    "owner",
+		Name:     "repo",
+		FullName: "owner/repo",
+		CheckID:  42,
+		SHA:      "new-sha",
+	}
+
+	_, err := c.DownloadArchive(context.Background(), pr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not mergeable")
+	// Only 1 call - no retries after seeing Mergeable=false
+	mockPR.AssertNumberOfCalls(t, "Get", 1)
+}
+
+func TestClient_DownloadArchive_ContextCancelled(t *testing.T) {
+	// If merge stays not-ready and context is cancelled, should return context error.
+	mockPR := new(githubMocks.MockPullRequestsServices)
+	mockPR.On("Get", mock.Anything, "owner", "repo", 42).Return(
+		&github.PullRequest{
+			Head:           &github.PullRequestBranch{SHA: github.Ptr("new-sha")},
+			MergeCommitSHA: github.Ptr("stale"),
+			Mergeable:      nil,
+		},
+		&github.Response{Response: &http.Response{StatusCode: 200}},
+		nil,
+	)
+
+	c := &Client{
+		googleClient: &GClient{PullRequests: mockPR},
+	}
+
+	pr := vcs.PullRequest{
+		Owner:    "owner",
+		Name:     "repo",
+		FullName: "owner/repo",
+		CheckID:  42,
+		SHA:      "new-sha",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel immediately so the backoff select picks it up
+	cancel()
+
+	_, err := c.DownloadArchive(ctx, pr)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestClient_DownloadArchive_GHEnterprise(t *testing.T) {
+	// Verify enterprise URL format.
+	mockPR := NewMockPullRequestsServicesWithGet(t,
+		prResponse{
+			headSHA:        "sha1",
+			mergeCommitSHA: "merge-sha",
+			mergeable:      github.Ptr(true),
+		},
+	)
+
+	c := &Client{
+		googleClient: &GClient{PullRequests: mockPR},
+		cfg:          config.ServerConfig{VcsBaseUrl: "https://github.example.com/api/v3"},
+	}
+
+	pr := vcs.PullRequest{
+		Owner:    "myorg",
+		Name:     "myrepo",
+		FullName: "myorg/myrepo",
+		CheckID:  1,
+		SHA:      "sha1",
+	}
+
+	url, err := c.DownloadArchive(context.Background(), pr)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.example.com/myorg/myrepo/archive/merge-sha.zip", url)
+}
+
+// --- test helpers ---
+
+type prResponse struct {
+	headSHA        string
+	mergeCommitSHA string
+	mergeable      *bool
+}
+
+// NewMockPullRequestsServicesWithGet creates a mock that returns the given
+// PR responses in order, one per call to Get.
+func NewMockPullRequestsServicesWithGet(t *testing.T, responses ...prResponse) *githubMocks.MockPullRequestsServices {
+	t.Helper()
+	mockPR := new(githubMocks.MockPullRequestsServices)
+
+	for _, resp := range responses {
+		pr := &github.PullRequest{
+			Head:      &github.PullRequestBranch{SHA: github.Ptr(resp.headSHA)},
+			Mergeable: resp.mergeable,
+		}
+		if resp.mergeCommitSHA != "" {
+			pr.MergeCommitSHA = github.Ptr(resp.mergeCommitSHA)
+		}
+		mockPR.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+			pr,
+			&github.Response{Response: &http.Response{StatusCode: 200}},
+			nil,
+		).Once()
+	}
+
+	return mockPR
+}

--- a/pkg/vcs/github_client/client_test.go
+++ b/pkg/vcs/github_client/client_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-github/v74/github"
 	"github.com/shurcooL/githubv4"
@@ -899,6 +900,7 @@ func TestClient_DownloadArchive_HappyPath(t *testing.T) {
 
 	c := &Client{
 		googleClient: &GClient{PullRequests: mockPR},
+		archiveRetry: fastRetry,
 	}
 
 	pr := vcs.PullRequest{
@@ -936,6 +938,7 @@ func TestClient_DownloadArchive_StaleMergeCommitThenReady(t *testing.T) {
 
 	c := &Client{
 		googleClient: &GClient{PullRequests: mockPR},
+		archiveRetry: fastRetry,
 	}
 
 	pr := vcs.PullRequest{
@@ -967,6 +970,7 @@ func TestClient_DownloadArchive_NotMergeable(t *testing.T) {
 
 	c := &Client{
 		googleClient: &GClient{PullRequests: mockPR},
+		archiveRetry: fastRetry,
 	}
 
 	pr := vcs.PullRequest{
@@ -995,10 +999,11 @@ func TestClient_DownloadArchive_ContextCancelled(t *testing.T) {
 		},
 		&github.Response{Response: &http.Response{StatusCode: 200}},
 		nil,
-	)
+	).Once()
 
 	c := &Client{
 		googleClient: &GClient{PullRequests: mockPR},
+		archiveRetry: fastRetry,
 	}
 
 	pr := vcs.PullRequest{
@@ -1016,6 +1021,7 @@ func TestClient_DownloadArchive_ContextCancelled(t *testing.T) {
 	_, err := c.DownloadArchive(ctx, pr)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+	mockPR.AssertExpectations(t)
 }
 
 func TestClient_DownloadArchive_GHEnterprise(t *testing.T) {
@@ -1031,6 +1037,7 @@ func TestClient_DownloadArchive_GHEnterprise(t *testing.T) {
 	c := &Client{
 		googleClient: &GClient{PullRequests: mockPR},
 		cfg:          config.ServerConfig{VcsBaseUrl: "https://github.example.com/api/v3"},
+		archiveRetry: fastRetry,
 	}
 
 	pr := vcs.PullRequest{
@@ -1047,6 +1054,13 @@ func TestClient_DownloadArchive_GHEnterprise(t *testing.T) {
 }
 
 // --- test helpers ---
+
+// fastRetry returns a retryConfig with near-zero delays for tests.
+var fastRetry = retryConfig{
+	maxRetries:     10,
+	initialBackoff: 1 * time.Millisecond,
+	maxBackoff:     1 * time.Millisecond,
+}
 
 type prResponse struct {
 	headSHA        string

--- a/pkg/vcs/github_client/hooks.go
+++ b/pkg/vcs/github_client/hooks.go
@@ -1,0 +1,197 @@
+package github_client
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+
+	"github.com/zapier/kubechecks/pkg"
+	"github.com/zapier/kubechecks/pkg/vcs"
+)
+
+func (c *Client) VerifyHook(r *http.Request, secret string) ([]byte, error) {
+	// GitHub provides the SHA256 of the secret + payload body, so we extract the body and compare
+	// We have to split it like this as the ValidatePayload method consumes the request
+	if secret != "" {
+		return github.ValidatePayload(r, []byte(secret))
+	} else {
+		// No secret provided, so we just grab the body
+		return io.ReadAll(r.Body)
+	}
+}
+
+func (c *Client) ParseHook(ctx context.Context, r *http.Request, request []byte) (vcs.PullRequest, error) {
+	payload, err := github.ParseWebHook(github.WebHookType(r), request)
+	if err != nil {
+		return nilPr, err
+	}
+
+	switch p := payload.(type) {
+	case *github.PullRequestEvent:
+		switch p.GetAction() {
+		case "opened", "synchronize", "reopened", "edited":
+			log.Info().Str("action", p.GetAction()).Msg("handling Github event from PR")
+			return c.buildRepoFromEvent(p), nil
+		default:
+			log.Info().Str("action", p.GetAction()).Msg("ignoring Github pull request event due to non commit based action")
+			return nilPr, vcs.ErrInvalidType
+		}
+	case *github.IssueCommentEvent:
+		switch p.GetAction() {
+		case "created":
+			if strings.ToLower(p.Comment.GetBody()) == c.cfg.ReplanCommentMessage {
+				log.Info().Msgf("Got %s comment, Running again", c.cfg.ReplanCommentMessage)
+				return c.buildRepoFromComment(ctx, p)
+			} else {
+				log.Info().Str("action", p.GetAction()).Msg("ignoring Github issue comment event due to non matching string")
+				return nilPr, vcs.ErrInvalidType
+			}
+		default:
+			log.Info().Str("action", p.GetAction()).Msg("ignoring Github issue comment due to invalid action")
+			return nilPr, vcs.ErrInvalidType
+		}
+	default:
+		log.Error().Msg("invalid event provided to Github client")
+		return nilPr, vcs.ErrInvalidType
+	}
+}
+
+func (c *Client) GetHookByUrl(ctx context.Context, ownerAndRepoName, webhookUrl string) (*vcs.WebHookConfig, error) {
+	owner, repoName := parseRepo(ownerAndRepoName)
+	items, _, err := c.googleClient.Repositories.ListHooks(ctx, owner, repoName, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list hooks")
+	}
+
+	for _, item := range items {
+		itemConfig := item.GetConfig()
+		// check if the hook's config has a URL
+		hookPayloadURL := ""
+		if itemConfig != nil {
+			hookPayloadURL = itemConfig.GetURL()
+		}
+		if hookPayloadURL == webhookUrl {
+			return &vcs.WebHookConfig{
+				Url:    hookPayloadURL,
+				Events: item.Events, // TODO: translate GH specific event names to VCS agnostic
+			}, nil
+		}
+	}
+
+	return nil, vcs.ErrHookNotFound
+}
+
+func (c *Client) CreateHook(ctx context.Context, ownerAndRepoName, webhookUrl, webhookSecret string) error {
+	owner, repoName := parseRepo(ownerAndRepoName)
+	_, resp, err := c.googleClient.Repositories.CreateHook(ctx, owner, repoName, &github.Hook{
+		Active: pkg.Pointer(true),
+		Config: &github.HookConfig{
+			ContentType: pkg.Pointer("json"),
+			InsecureSSL: pkg.Pointer("0"),
+			URL:         pkg.Pointer(webhookUrl),
+			Secret:      pkg.Pointer(webhookSecret),
+		},
+		Events: []string{
+			"pull_request", "issue_comment",
+		},
+		Name: pkg.Pointer("web"),
+	})
+	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		statusCode := 0
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		return errors.Wrap(err, fmt.Sprintf("failed to create hook, statuscode: %d", statusCode))
+	}
+	return nil
+}
+
+var rePullRequest = regexp.MustCompile(`(.*)/(.*)#(\d+)`)
+
+func (c *Client) LoadHook(ctx context.Context, id string) (vcs.PullRequest, error) {
+	m := rePullRequest.FindStringSubmatch(id)
+	if len(m) != 4 {
+		return nilPr, errors.New("must be in format OWNER/REPO#PR")
+	}
+
+	ownerName := m[1]
+	repoName := m[2]
+	prNumber, err := strconv.ParseInt(m[3], 10, 32)
+	if err != nil {
+		return nilPr, errors.Wrap(err, "failed to parse int")
+	}
+
+	repoInfo, _, err := c.googleClient.Repositories.Get(ctx, ownerName, repoName)
+	if err != nil {
+		return nilPr, errors.Wrap(err, "failed to get repo")
+	}
+
+	pullRequest, _, err := c.googleClient.PullRequests.Get(ctx, ownerName, repoName, int(prNumber))
+	if err != nil {
+		return nilPr, errors.Wrap(err, "failed to get pull request")
+	}
+
+	var labels []string
+	for _, label := range pullRequest.Labels {
+		labels = append(labels, label.GetName())
+	}
+
+	var (
+		baseRef                    string
+		headRef, headSha           string
+		login, userName, userEmail string
+	)
+
+	if pullRequest.Base != nil {
+		baseRef = unPtr(pullRequest.Base.Ref)
+		headRef = unPtr(pullRequest.Head.Ref)
+	}
+
+	if repoInfo.Owner != nil {
+		login = unPtr(repoInfo.Owner.Login)
+	} else {
+		login = "kubechecks"
+	}
+
+	if pullRequest.Head != nil {
+		headSha = unPtr(pullRequest.Head.SHA)
+	}
+
+	if pullRequest.User != nil {
+		userName = unPtr(pullRequest.User.Name)
+		userEmail = unPtr(pullRequest.User.Email)
+	}
+
+	// these are required for `git merge` later on
+	if userName == "" {
+		userName = "kubechecks"
+	}
+	if userEmail == "" {
+		userEmail = "kubechecks@github.com"
+	}
+
+	return vcs.PullRequest{
+		BaseRef:       baseRef,
+		HeadRef:       headRef,
+		DefaultBranch: unPtr(repoInfo.DefaultBranch),
+		CloneURL:      unPtr(repoInfo.CloneURL),
+		FullName:      repoInfo.GetFullName(),
+		Owner:         login,
+		Name:          repoInfo.GetName(),
+		CheckID:       int(prNumber),
+		SHA:           headSha,
+		Username:      userName,
+		Email:         userEmail,
+		Labels:        labels,
+
+		Config: c.cfg,
+	}, nil
+}

--- a/pkg/vcs/github_client/retry.go
+++ b/pkg/vcs/github_client/retry.go
@@ -1,0 +1,39 @@
+package github_client
+
+import "time"
+
+// retryConfig holds retry/backoff parameters for polling loops.
+// Zero values mean "use defaults".
+type retryConfig struct {
+	maxRetries     int
+	initialBackoff time.Duration
+	maxBackoff     time.Duration
+}
+
+func (r retryConfig) withDefaults(maxRetries int, initialBackoff, maxBackoff time.Duration) retryConfig {
+	// Apply defaults for zero values.
+	if r.maxRetries == 0 {
+		r.maxRetries = maxRetries
+	}
+	if r.initialBackoff == 0 {
+		r.initialBackoff = initialBackoff
+	}
+	if r.maxBackoff == 0 {
+		r.maxBackoff = maxBackoff
+	}
+	// Normalize: clamp negative/zero values to safe minimums.
+	if r.maxRetries < 0 {
+		r.maxRetries = 0
+	}
+	if r.initialBackoff <= 0 {
+		r.initialBackoff = initialBackoff
+	}
+	if r.maxBackoff <= 0 {
+		r.maxBackoff = maxBackoff
+	}
+	// Ensure maxBackoff is never less than initialBackoff.
+	if r.maxBackoff < r.initialBackoff {
+		r.maxBackoff = r.initialBackoff
+	}
+	return r
+}

--- a/pkg/vcs/github_client/status.go
+++ b/pkg/vcs/github_client/status.go
@@ -1,0 +1,43 @@
+package github_client
+
+import (
+	"context"
+
+	"github.com/google/go-github/v74/github"
+	"github.com/rs/zerolog/log"
+
+	"github.com/zapier/kubechecks/pkg"
+	"github.com/zapier/kubechecks/pkg/vcs"
+)
+
+func toGithubCommitStatus(state pkg.CommitState) *string {
+	switch state {
+	case pkg.StateError, pkg.StatePanic:
+		return pkg.Pointer("error")
+	case pkg.StateFailure:
+		return pkg.Pointer("failure")
+	case pkg.StateRunning:
+		return pkg.Pointer("pending")
+	case pkg.StateSuccess, pkg.StateWarning, pkg.StateNone, pkg.StateSkip:
+		return pkg.Pointer("success")
+	}
+
+	log.Warn().Str("state", state.BareString()).Msg("failed to convert to a github commit status")
+	return pkg.Pointer("failure")
+}
+
+func (c *Client) CommitStatus(ctx context.Context, pr vcs.PullRequest, status pkg.CommitState) error {
+	log.Info().Str("repo", pr.Name).Str("sha", pr.SHA).Str("status", status.BareString()).Msg("setting Github commit status")
+	repoStatus, _, err := c.googleClient.Repositories.CreateStatus(ctx, pr.Owner, pr.Name, pr.SHA, &github.RepoStatus{
+		State:       toGithubCommitStatus(status),
+		Description: pkg.Pointer(status.BareString()),
+		ID:          pkg.Pointer(int64(pr.CheckID)),
+		Context:     pkg.Pointer("kubechecks"),
+	})
+	if err != nil {
+		log.Err(err).Msg("could not set Github commit status")
+		return err
+	}
+	log.Debug().Caller().Interface("status", repoStatus).Msg("Github commit status set")
+	return nil
+}


### PR DESCRIPTION
  - Fix race condition where pushing a new commit to an existing PR causes kubechecks to download the archive for the previous merge commit instead of the current one
  - When a new commit is pushed, GitHub updates head.sha immediately but merge_commit_sha remains stale until the merge is recomputed. During this window, Mergeable is nil. The old code only checked that head.sha matched and merge_commit_sha was non-empty — both could be true while the merge commit was still from the old HEAD.
  - Now the retry loop also waits for Mergeable != nil before trusting merge_commit_sha
  - Increased retries (5 → 10) and backoff (500ms/8s → 1s/16s) to accommodate GitHub's merge recomputation time