### PR TITLE
Local dev secrets management

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -7,4 +7,4 @@ kubeconform 0.7.0
 kustomize 5.8.0
 mockery 3.3.4
 tilt 0.33.2
-
+python 3.14.3

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ setup-buildx: ## Setup Docker Buildx builder
 build: ## Build single-platform production image (local architecture)
 	@echo "==> Building production image for local platform..."
 	docker buildx build \
+		--builder $(BUILDER_NAME) \
 		--target production \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \
@@ -107,6 +108,7 @@ build: ## Build single-platform production image (local architecture)
 build-debug: ## Build debug image with delve for local development
 	@echo "==> Building debug image with delve..."
 	docker buildx build \
+		--builder $(BUILDER_NAME) \
 		--target debug \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg ALPINE_VERSION=$(ALPINE_VERSION) \

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ setup-buildx: ## Setup Docker Buildx builder
 # Build Targets
 # ============================================================================
 
-build: ## Build single-platform production image (local architecture)
+build: setup-buildx ## Build single-platform production image (local architecture)
 	@echo "==> Building production image for local platform..."
 	docker buildx build \
 		--builder $(BUILDER_NAME) \
@@ -105,7 +105,7 @@ build: ## Build single-platform production image (local architecture)
 	@echo "    Image: $(IMAGE_NAME):$(IMAGE_TAG)"
 	@docker images $(IMAGE_NAME):$(IMAGE_TAG) --format "    Size:  {{.Size}}"
 
-build-debug: ## Build debug image with delve for local development
+build-debug: setup-buildx ## Build debug image with delve for local development
 	@echo "==> Building debug image with delve..."
 	docker buildx build \
 		--builder $(BUILDER_NAME) \

--- a/Tiltfile
+++ b/Tiltfile
@@ -8,11 +8,57 @@ load('ext://local_output', 'local_output')
 load('./.tilt/terraform/Tiltfile', 'local_terraform_resource')
 load('./.tilt/utils/Tiltfile', 'check_env_set')
 
-# Check if the .secret file exists
-if not os.path.exists('.secret'):
-    fail('The .secret file is missing. Please copy .secret file from .secret.example and setup before running Tilt.')
+# /////////////////////////////////////////////////////////////////////////////
+# S E C R E T S
+# /////////////////////////////////////////////////////////////////////////////
+# Secrets are loaded from the OS keychain (macOS Keychain / Linux pass).
+# Fallback to .secret file for backwards compatibility.
+#
+# Setup (one-time):
+#   macOS:  security add-generic-password -a "$USER" -s "kubechecks/<KEY_NAME>" -w "<value>"
+#   Linux:  pass insert kubechecks/<KEY_NAME>
+#
+# See docs/contributing.md for full setup instructions.
 
-dotenv(fn='.secret')
+def _get_secret(key_name, required=False):
+    """Retrieve a secret from OS keychain, falling back to environment variable."""
+    os_name = str(local('uname -s', quiet=True)).strip()
+    val = ''
+    if os_name == 'Darwin':
+        val = str(local(
+            'security find-generic-password -a "$USER" -s "kubechecks/%s" -w 2>/dev/null || echo ""' % key_name,
+            quiet=True,
+        )).strip()
+    else:
+        # Linux: use pass (password-store)
+        val = str(local(
+            'pass kubechecks/%s 2>/dev/null || echo ""' % key_name,
+            quiet=True,
+        )).strip()
+
+    if val == '' and os.getenv(key_name):
+        val = os.getenv(key_name)
+    if val == '' and required:
+        fail('Secret "%s" not found in keychain or environment. See docs/contributing.md for setup instructions.' % key_name)
+    return val
+
+# Load .secret file if it exists (backwards compatible)
+if os.path.exists('.secret'):
+    dotenv(fn='.secret')
+
+# Load secrets from keychain (overrides .secret file values)
+_gitlab_token = _get_secret('GITLAB_TOKEN')
+_github_token = _get_secret('GITHUB_TOKEN')
+_webhook_secret = _get_secret('KUBECHECKS_WEBHOOK_SECRET')
+_openai_token = _get_secret('OPENAI_API_TOKEN')
+_anthropic_key = _get_secret('ANTHROPIC_API_KEY')
+
+# Make secrets available as env vars for Tilt resources
+if _gitlab_token: os.putenv('GITLAB_TOKEN', _gitlab_token)
+if _github_token: os.putenv('GITHUB_TOKEN', _github_token)
+if _webhook_secret: os.putenv('KUBECHECKS_WEBHOOK_SECRET', _webhook_secret)
+if _openai_token: os.putenv('OPENAI_API_TOKEN', _openai_token)
+if _anthropic_key: os.putenv('ANTHROPIC_API_KEY', _anthropic_key)
 
 config.define_bool("enable_repo", True, 'create a new project for testing this app')
 config.define_string("vcs-type")
@@ -81,10 +127,9 @@ if cfg.get('enable_repo', True):
       'tf-vcs',
       dir='./localdev/terraform/gitlab',
       env={
-        'GITLAB_TOKEN': os.getenv('GITLAB_TOKEN'),
+        'GITLAB_TOKEN': _gitlab_token,
         'TF_VAR_ngrok_url': get_ngrok_url(cfg),
-        'TF_VAR_kubechecks_gitlab_hook_secret_key': os.getenv('KUBECHECKS_WEBHOOK_SECRET') if os.getenv('KUBECHECKS_WEBHOOK_SECRET') != None else "",
-
+        'TF_VAR_kubechecks_gitlab_hook_secret_key': _webhook_secret,
       },
       deps=[
         './localdev/terraform/*.tf',
@@ -106,9 +151,9 @@ if cfg.get('enable_repo', True):
       'tf-vcs',
       dir='./localdev/terraform/github',
       env={
-        'GITHUB_TOKEN': os.getenv('GITHUB_TOKEN'),
+        'GITHUB_TOKEN': _github_token,
         'TF_VAR_ngrok_url': get_ngrok_url(cfg),
-        'TF_VAR_kubechecks_github_hook_secret_key': os.getenv('KUBECHECKS_WEBHOOK_SECRET') if os.getenv('KUBECHECKS_WEBHOOK_SECRET') != None else "",
+        'TF_VAR_kubechecks_github_hook_secret_key': _webhook_secret,
       },
       deps=[
         './localdev/terraform/*.tf',
@@ -175,7 +220,9 @@ tool_versions = parse_tool_versions(".tool-versions")
 git_commit = local_output('git rev-parse --short HEAD')
 git_tag = local_output('git describe --tags --always --dirty 2>/dev/null || echo "dev"')
 
-# Docker Buildx build via Makefile (works around Tilt v0.33.6 docker_build issues)
+# Docker Buildx build via Makefile
+# Note: Docker Desktop must have "Use containerd for pulling and storing images" enabled
+# in Settings > General so that Kubernetes and Docker share the same image store.
 custom_build(
     'kubechecks',
     'make build-debug IMAGE_TAG=$EXPECTED_TAG',
@@ -207,21 +254,25 @@ cmd_button('restart-pod',
 )
 
 
+# Build helm flags, only including secrets that are actually set
+_helm_flags = [
+    '--values=./localdev/kubechecks/values.yaml',
+    '--set=configMap.env.KUBECHECKS_WEBHOOK_URL_BASE=' + get_ngrok_url(cfg),
+    '--set=configMap.env.NGROK_URL=' + get_ngrok_url(cfg),
+    '--set=configMap.env.KUBECHECKS_ARGOCD_WEBHOOK_URL=' + get_ngrok_url(cfg) +'/argocd/api/webhook',
+    '--set=configMap.env.KUBECHECKS_VCS_TYPE=' + cfg.get('vcs-type', 'gitlab'),
+    '--set=secrets.env.KUBECHECKS_VCS_TOKEN=' + (_gitlab_token if 'gitlab' in cfg.get('vcs-type', 'gitlab') else _github_token),
+]
+if _webhook_secret: _helm_flags.append('--set=secrets.env.KUBECHECKS_WEBHOOK_SECRET=' + _webhook_secret)
+if _openai_token:   _helm_flags.append('--set=secrets.env.KUBECHECKS_OPENAI_API_TOKEN=' + _openai_token)
+if _anthropic_key:  _helm_flags.append('--set=secrets.env.KUBECHECKS_ANTHROPIC_API_KEY=' + _anthropic_key)
+
 helm_resource(name='kubechecks',
               chart='./charts/kubechecks',
               image_deps=['kubechecks'],
               image_keys=[('deployment.image.name', 'deployment.image.tag')],
               namespace= k8s_namespace,
-              flags=[
-                '--values=./localdev/kubechecks/values.yaml',
-                '--set=configMap.env.KUBECHECKS_WEBHOOK_URL_BASE=' + get_ngrok_url(cfg),
-                '--set=configMap.env.NGROK_URL=' + get_ngrok_url(cfg),
-                '--set=configMap.env.KUBECHECKS_ARGOCD_WEBHOOK_URL=' + get_ngrok_url(cfg) +'/argocd/api/webhook',
-                '--set=configMap.env.KUBECHECKS_VCS_TYPE=' + cfg.get('vcs-type', 'gitlab'),
-                '--set=secrets.env.KUBECHECKS_VCS_TOKEN=' + (os.getenv('GITLAB_TOKEN') if 'gitlab' in cfg.get('vcs-type', 'gitlab') else os.getenv('GITHUB_TOKEN')),
-                '--set=secrets.env.KUBECHECKS_WEBHOOK_SECRET=' + (os.getenv('KUBECHECKS_WEBHOOK_SECRET') if os.getenv('KUBECHECKS_WEBHOOK_SECRET') != None else ""),
-                '--set=secrets.env.KUBECHECKS_OPENAI_API_TOKEN=' + (os.getenv('OPENAI_API_TOKEN') if os.getenv('OPENAI_API_TOKEN') != None else ""),
-              ],
+              flags=_helm_flags,
               labels=["kubechecks"],
               resource_deps=[
                 'k8s:namespace',

--- a/Tiltfile
+++ b/Tiltfile
@@ -19,12 +19,12 @@ load('./.tilt/utils/Tiltfile', 'check_env_set')
 #   Linux:  pass insert kubechecks/<KEY_NAME>
 #
 # See docs/contributing.md for full setup instructions.
+_os_name = str(local('uname -s', quiet=True)).strip()
 
 def _get_secret(key_name, required=False):
     """Retrieve a secret from OS keychain, falling back to environment variable."""
-    os_name = str(local('uname -s', quiet=True)).strip()
     val = ''
-    if os_name == 'Darwin':
+    if _os_name == 'Darwin':
         val = str(local(
             'security find-generic-password -a "$USER" -s "kubechecks/%s" -w 2>/dev/null || echo ""' % key_name,
             quiet=True,
@@ -254,18 +254,40 @@ cmd_button('restart-pod',
 )
 
 
-# Build helm flags, only including secrets that are actually set
+# Keychain-loaded secrets are applied via k8s_yaml(blob(...)) so their values
+# never appear on a helm CLI arg (visible to `ps`) or on disk. Tilt auto-scrubs
+# values of applied Secrets from its log panes (secret_settings is a builtin).
+secret_settings(disable_scrub=False)
+
+_vcs_token = _gitlab_token if 'gitlab' in cfg.get('vcs-type', 'gitlab') else _github_token
+_local_secret_name = 'kubechecks-local-secrets'
+_local_secret_data = {'KUBECHECKS_VCS_TOKEN': _vcs_token}
+if _webhook_secret: _local_secret_data['KUBECHECKS_WEBHOOK_SECRET'] = _webhook_secret
+if _openai_token:   _local_secret_data['KUBECHECKS_OPENAI_API_TOKEN'] = _openai_token
+if _anthropic_key:  _local_secret_data['KUBECHECKS_ANTHROPIC_API_KEY'] = _anthropic_key
+
+k8s_yaml(encode_yaml({
+    'apiVersion': 'v1',
+    'kind': 'Secret',
+    'metadata': {'name': _local_secret_name, 'namespace': k8s_namespace},
+    'type': 'Opaque',
+    'stringData': _local_secret_data,
+}))
+k8s_resource(
+    objects=[_local_secret_name + ':secret'],
+    new_name=_local_secret_name,
+    resource_deps=['k8s:namespace'],
+    labels=['kubechecks'],
+)
+
 _helm_flags = [
     '--values=./localdev/kubechecks/values.yaml',
+    '--values=./localdev/kubechecks/secrets-values.yaml',
     '--set=configMap.env.KUBECHECKS_WEBHOOK_URL_BASE=' + get_ngrok_url(cfg),
     '--set=configMap.env.NGROK_URL=' + get_ngrok_url(cfg),
     '--set=configMap.env.KUBECHECKS_ARGOCD_WEBHOOK_URL=' + get_ngrok_url(cfg) +'/argocd/api/webhook',
     '--set=configMap.env.KUBECHECKS_VCS_TYPE=' + cfg.get('vcs-type', 'gitlab'),
-    '--set=secrets.env.KUBECHECKS_VCS_TOKEN=' + (_gitlab_token if 'gitlab' in cfg.get('vcs-type', 'gitlab') else _github_token),
 ]
-if _webhook_secret: _helm_flags.append('--set=secrets.env.KUBECHECKS_WEBHOOK_SECRET=' + _webhook_secret)
-if _openai_token:   _helm_flags.append('--set=secrets.env.KUBECHECKS_OPENAI_API_TOKEN=' + _openai_token)
-if _anthropic_key:  _helm_flags.append('--set=secrets.env.KUBECHECKS_ANTHROPIC_API_KEY=' + _anthropic_key)
 
 helm_resource(name='kubechecks',
               chart='./charts/kubechecks',
@@ -276,6 +298,7 @@ helm_resource(name='kubechecks',
               labels=["kubechecks"],
               resource_deps=[
                 'k8s:namespace',
+                _local_secret_name,
                 'argocd',
                 'argocd-crds',
                 'tf-vcs' if cfg.get('enable_repo', True) else '',

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,25 +68,27 @@ To get started do the following:
 
 #### 1. Store secrets in your OS keychain
 
-Secrets are loaded from your OS keychain at `tilt up` time. No plaintext secret files are stored on disk.
+The OS keychain is the recommended path: secrets are loaded at `tilt up` time and never written to disk by Tilt. (A `.secret` file fallback still exists for backwards compatibility — see below — but that path *does* keep plaintext on disk and should be avoided.)
 
 **macOS (Keychain Access):**
 
+> Note: the examples below use `-w` with **no value** on purpose, so `security` prompts for the secret interactively and it never lands in your shell history (or briefly in `ps`). Avoid the `-w "<value>"` form.
+
 ```sh
 # Required: one of GITLAB_TOKEN or GITHUB_TOKEN
-security add-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -w "glpat-xxxxxxxxxxxx"
+security add-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -w
 # or
-security add-generic-password -a "$USER" -s "kubechecks/GITHUB_TOKEN" -w "ghp_xxxxxxxxxxxx"
+security add-generic-password -a "$USER" -s "kubechecks/GITHUB_TOKEN" -w
 
 # Optional
-security add-generic-password -a "$USER" -s "kubechecks/KUBECHECKS_WEBHOOK_SECRET" -w "your-webhook-secret"
-security add-generic-password -a "$USER" -s "kubechecks/OPENAI_API_TOKEN" -w "sk-xxxxxxxxxxxx"
-security add-generic-password -a "$USER" -s "kubechecks/ANTHROPIC_API_KEY" -w "sk-ant-xxxxxxxxxxxx"
+security add-generic-password -a "$USER" -s "kubechecks/KUBECHECKS_WEBHOOK_SECRET" -w
+security add-generic-password -a "$USER" -s "kubechecks/OPENAI_API_TOKEN" -w
+security add-generic-password -a "$USER" -s "kubechecks/ANTHROPIC_API_KEY" -w
 ```
 
-To update an existing secret, add the `-U` flag:
+To update an existing secret, add the `-U` flag (still omit the value so it prompts):
 ```sh
-security add-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -w "new-value" -U
+security add-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -U -w
 ```
 
 To verify a secret is stored:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -66,28 +66,98 @@ It creates:
 
 To get started do the following:
 
-* Copy the `.secret.example` and set required values.
+#### 1. Store secrets in your OS keychain
 
-    ```sh
-    cp .secret.example .secret
-    ```
+Secrets are loaded from your OS keychain at `tilt up` time. No plaintext secret files are stored on disk.
 
-    You will need to fill in either `GITLAB_TOKEN` or `GITLAB_TOKEN`  
-    If you are testing with GITHUB, please set the tilt_config.json file to specify the vcs-type as the default is `gitlab`:
+**macOS (Keychain Access):**
 
-      ```json title="tilt_config.json"
-      {
-        "vcs-type": "github"
-      }
-      ```
+```sh
+# Required: one of GITLAB_TOKEN or GITHUB_TOKEN
+security add-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -w "glpat-xxxxxxxxxxxx"
+# or
+security add-generic-password -a "$USER" -s "kubechecks/GITHUB_TOKEN" -w "ghp_xxxxxxxxxxxx"
 
-    The token you specify must have ability to get repositories, add/delete comment and webhooks.
+# Optional
+security add-generic-password -a "$USER" -s "kubechecks/KUBECHECKS_WEBHOOK_SECRET" -w "your-webhook-secret"
+security add-generic-password -a "$USER" -s "kubechecks/OPENAI_API_TOKEN" -w "sk-xxxxxxxxxxxx"
+security add-generic-password -a "$USER" -s "kubechecks/ANTHROPIC_API_KEY" -w "sk-ant-xxxxxxxxxxxx"
+```
 
-* From the root directory of this repo:
+To update an existing secret, add the `-U` flag:
+```sh
+security add-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -w "new-value" -U
+```
 
-    ```sh
-    tilt up
-    ```
+To verify a secret is stored:
+```sh
+security find-generic-password -a "$USER" -s "kubechecks/GITLAB_TOKEN" -w
+```
+
+**Linux (pass - password-store):**
+
+First, install and initialize `pass` if you haven't already:
+```sh
+# Ubuntu/Debian
+sudo apt install pass
+
+# Fedora/RHEL
+sudo dnf install pass
+
+# Arch
+sudo pacman -S pass
+
+# Initialize with your GPG key (one-time setup)
+gpg --gen-key           # if you don't have a GPG key yet
+pass init "your-email@example.com"
+```
+
+Then store your secrets:
+```sh
+# Required: one of GITLAB_TOKEN or GITHUB_TOKEN
+pass insert kubechecks/GITLAB_TOKEN
+# or
+pass insert kubechecks/GITHUB_TOKEN
+
+# Optional
+pass insert kubechecks/KUBECHECKS_WEBHOOK_SECRET
+pass insert kubechecks/OPENAI_API_TOKEN
+pass insert kubechecks/ANTHROPIC_API_KEY
+```
+
+To verify a secret is stored:
+```sh
+pass kubechecks/GITLAB_TOKEN
+```
+
+**Fallback (.secret file):**
+
+For backwards compatibility, the Tiltfile still supports the `.secret` file approach. If a `.secret` file exists, it will be loaded first, with keychain values taking precedence.
+
+```sh
+cp .secret.example .secret
+# Edit .secret with your values
+```
+
+#### 2. Configure VCS type
+
+The token you specify must have the ability to get repositories, add/delete comments, and manage webhooks.
+
+If you are testing with GitHub, set the `tilt_config.json` file to specify the vcs-type (default is `gitlab`):
+
+```json title="tilt_config.json"
+{
+    "vcs-type": "github"
+}
+```
+
+#### 3. Start Tilt
+
+From the root directory of this repo:
+
+```sh
+tilt up
+```
 
 You should see output like:
 

--- a/localdev/kubechecks/secrets-values.yaml
+++ b/localdev/kubechecks/secrets-values.yaml
@@ -1,0 +1,4 @@
+deployment:
+  envFrom:
+    - secretRef:
+        name: kubechecks-local-secrets


### PR DESCRIPTION
## Why this change?
There has been an increase in supply chain attacks that scan local files (especially .env) and exfiltrate API tokens and passwords. This change is the first step toward preventing the local dev environment from using a clear-text secret store (.secret) and instead using the OS's own secret store, such as macOS' Keychain Access. 

## What is changed?
- Tiltfile updated to load secrets from OS keychain (macOS Keychain / Linux `pass`) instead of plaintext `.secret` file
- Backwards compatible — `.secret` file still works as a fallback
- Contributing docs updated with setup instructions for both platforms
- Buildx step updated to use the same worker as other steps.
