### PR TITLE
k8s versions are assumed to be major.minor.0

### DIFF
--- a/pkg/events/worker.go
+++ b/pkg/events/worker.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ghodss/yaml"
+	"github.com/masterminds/semver"
 	"github.com/rs/zerolog/log"
 	"github.com/zapier/kubechecks/pkg/vcs"
 	"go.opentelemetry.io/otel/attribute"
@@ -115,10 +116,10 @@ func (w *worker) processApp(ctx context.Context, app v1alpha1.Application) {
 	if err != nil {
 		rootLogger.Error().Caller().Err(err).Msg("Error retrieving the Kubernetes version")
 		k8sVersion = w.ctr.Config.FallbackK8sVersion
-	} else {
-		k8sVersion = fmt.Sprintf("%s.0", k8sVersion)
-		rootLogger.Info().Msgf("Kubernetes version: %s", k8sVersion)
 	}
+	rootLogger.Debug().Msgf("Kubernetes version (raw): %s", k8sVersion)
+	k8sVersion = normalizeK8sVersion(k8sVersion)
+	rootLogger.Info().Msgf("Kubernetes version (normalized): %s", k8sVersion)
 
 	runner := newRunner(w.ctr, app, appName, k8sVersion, jsonManifests, yamlManifests, rootLogger, w.vcsNote, w.queueApp, w.removeApp)
 
@@ -127,6 +128,21 @@ func (w *worker) processApp(ctx context.Context, app v1alpha1.Application) {
 	}
 
 	runner.Wait()
+}
+
+// normalizeK8sVersion normalizes a Kubernetes version string to the format v$major.$minor.0.
+// It handles various input formats:
+//   - v1 -> v1.0.0
+//   - v1.2 -> v1.2.0
+//   - v1.2.3 -> v1.2.0 (patch is always zeroed)
+//   - v1.2.3+build -> v1.2.0 (metadata stripped, patch zeroed)
+//   - 1.2 -> v1.2.0 (v prefix added)
+func normalizeK8sVersion(version string) string {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return "v0.0.0"
+	}
+	return fmt.Sprintf("v%d.%d.0", v.Major(), v.Minor())
 }
 
 func convertJsonToYamlManifests(jsonManifests []string) []string {

--- a/pkg/events/worker.go
+++ b/pkg/events/worker.go
@@ -118,7 +118,7 @@ func (w *worker) processApp(ctx context.Context, app v1alpha1.Application) {
 		k8sVersion = w.ctr.Config.FallbackK8sVersion
 	}
 	rootLogger.Debug().Msgf("Kubernetes version (raw): %s", k8sVersion)
-	k8sVersion = normalizeK8sVersion(k8sVersion)
+	k8sVersion = normalizeK8sVersion(k8sVersion, w.ctr.Config.FallbackK8sVersion)
 	rootLogger.Info().Msgf("Kubernetes version (normalized): %s", k8sVersion)
 
 	runner := newRunner(w.ctr, app, appName, k8sVersion, jsonManifests, yamlManifests, rootLogger, w.vcsNote, w.queueApp, w.removeApp)
@@ -137,10 +137,10 @@ func (w *worker) processApp(ctx context.Context, app v1alpha1.Application) {
 //   - v1.2.3 -> v1.2.0 (patch is always zeroed)
 //   - v1.2.3+build -> v1.2.0 (metadata stripped, patch zeroed)
 //   - 1.2 -> v1.2.0 (v prefix added)
-func normalizeK8sVersion(version string) string {
+func normalizeK8sVersion(version, fallbackVersion string) string {
 	v, err := semver.NewVersion(version)
 	if err != nil {
-		return "v0.0.0"
+		return fallbackVersion
 	}
 	return fmt.Sprintf("v%d.%d.0", v.Major(), v.Minor())
 }

--- a/pkg/events/worker_test.go
+++ b/pkg/events/worker_test.go
@@ -1,55 +1,14 @@
 package events
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetK8sVersionWithFallback(t *testing.T) {
-	const fallbackVersion = "v1.25.0"
-
-	testcases := map[string]struct {
-		version  string
-		err      error
-		expected string
-	}{
-		"success with major.minor": {
-			version:  "v1.28",
-			err:      nil,
-			expected: "v1.28.0",
-		},
-		"success with full version - patch zeroed": {
-			version:  "v1.28.5",
-			err:      nil,
-			expected: "v1.28.0",
-		},
-		"success with build metadata - patch zeroed": {
-			version:  "v1.28.5+k3s1",
-			err:      nil,
-			expected: "v1.28.0",
-		},
-		"error returns fallback": {
-			version:  "",
-			err:      errors.New("cluster not found"),
-			expected: fallbackVersion,
-		},
-		"empty version with no error returns fallback": {
-			version:  "",
-			err:      errors.New("no version found"),
-			expected: fallbackVersion,
-		},
-	}
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			actual := getK8sVersionWithFallback(tc.version, tc.err, fallbackVersion)
-			assert.Equal(t, tc.expected, actual)
-		})
-	}
-}
-
 func TestNormalizeK8sVersion(t *testing.T) {
+	fallbackVersion := "fallback"
+
 	testcases := map[string]struct {
 		input    string
 		expected string
@@ -86,10 +45,14 @@ func TestNormalizeK8sVersion(t *testing.T) {
 			input:    "1.28.5",
 			expected: "v1.28.0",
 		},
+		"invalid version": {
+			input:    "just-testing",
+			expected: fallbackVersion,
+		},
 	}
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			actual := normalizeK8sVersion(tc.input)
+			actual := normalizeK8sVersion(tc.input, fallbackVersion)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}

--- a/pkg/events/worker_test.go
+++ b/pkg/events/worker_test.go
@@ -1,10 +1,99 @@
 package events
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGetK8sVersionWithFallback(t *testing.T) {
+	const fallbackVersion = "v1.25.0"
+
+	testcases := map[string]struct {
+		version  string
+		err      error
+		expected string
+	}{
+		"success with major.minor": {
+			version:  "v1.28",
+			err:      nil,
+			expected: "v1.28.0",
+		},
+		"success with full version - patch zeroed": {
+			version:  "v1.28.5",
+			err:      nil,
+			expected: "v1.28.0",
+		},
+		"success with build metadata - patch zeroed": {
+			version:  "v1.28.5+k3s1",
+			err:      nil,
+			expected: "v1.28.0",
+		},
+		"error returns fallback": {
+			version:  "",
+			err:      errors.New("cluster not found"),
+			expected: fallbackVersion,
+		},
+		"empty version with no error returns fallback": {
+			version:  "",
+			err:      errors.New("no version found"),
+			expected: fallbackVersion,
+		},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := getK8sVersionWithFallback(tc.version, tc.err, fallbackVersion)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestNormalizeK8sVersion(t *testing.T) {
+	testcases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"major only": {
+			input:    "v1",
+			expected: "v1.0.0",
+		},
+		"major.minor": {
+			input:    "v1.2",
+			expected: "v1.2.0",
+		},
+		"full version - patch zeroed": {
+			input:    "v1.2.3",
+			expected: "v1.2.0",
+		},
+		"version with build metadata - patch zeroed": {
+			input:    "v1.2.3+debug1",
+			expected: "v1.2.0",
+		},
+		"version with prerelease - patch zeroed": {
+			input:    "v1.2.3-alpha",
+			expected: "v1.2.0",
+		},
+		"version with prerelease and build - patch zeroed": {
+			input:    "v1.2.3-beta+build.123",
+			expected: "v1.2.0",
+		},
+		"major.minor without v prefix": {
+			input:    "1.28",
+			expected: "v1.28.0",
+		},
+		"full version without v prefix - patch zeroed": {
+			input:    "1.28.5",
+			expected: "v1.28.0",
+		},
+	}
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actual := normalizeK8sVersion(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
 
 func TestConvertJsonToYamlManifests(t *testing.T) {
 	testcases := map[string]struct {


### PR DESCRIPTION
It can cause odd issues if that's not true. Not sure if it's argocd, kubernetes, or rackspace, but I've run into a situation lately where argocd reports kubernetes as "1.32.9" instead of "1.32", which causes mismatches in kubepug and kubeconform. This ensures that versions are expected to be consistent.