### PR TITLE
feat: expand wildcard Helm value file paths when packaging apps

### DIFF
--- a/pkg/argo_client/helm_values.go
+++ b/pkg/argo_client/helm_values.go
@@ -21,7 +21,17 @@ func containsGlob(path string) bool {
 // preserving its location relative to the source app directory. The original
 // glob entry is left in source.Helm.ValueFiles so the Argo CD repo server can
 // expand it once it receives the package.
-func copyGlobValueFiles(srcAppPath, destAppDir string, source v1alpha1.ApplicationSource, valueFile string) error {
+//
+// repoRoot anchors the source side and destDir anchors the destination side.
+// The function rejects absolute valueFile paths and any expanded match or
+// computed destination that escapes its respective root, so a maliciously
+// crafted Application spec cannot read or write files outside the repo / temp
+// package directory.
+func copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir string, source v1alpha1.ApplicationSource, valueFile string) error {
+	if filepath.IsAbs(valueFile) {
+		return fmt.Errorf("absolute value file paths are not permitted: %q", valueFile)
+	}
+
 	pattern := filepath.Join(srcAppPath, valueFile)
 	matches, err := filepath.Glob(pattern)
 	if err != nil {
@@ -38,12 +48,38 @@ func copyGlobValueFiles(srcAppPath, destAppDir string, source v1alpha1.Applicati
 		return fmt.Errorf("glob value file %q matched no files", valueFile)
 	}
 
+	resolvedRepoRoot, err := resolveExisting(repoRoot)
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve repo root")
+	}
+	absDestDir, err := absClean(destDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to resolve package dir")
+	}
+
 	for _, match := range matches {
+		resolvedMatch, err := resolveExisting(match)
+		if err != nil {
+			return errors.Wrapf(err, "failed to resolve %q", match)
+		}
+		if !isWithin(resolvedMatch, resolvedRepoRoot) {
+			return fmt.Errorf("globbed value file %q escapes repo root", match)
+		}
+
 		relFromAppPath, err := filepath.Rel(srcAppPath, match)
 		if err != nil {
 			return errors.Wrapf(err, "failed to compute relative path for %q", match)
 		}
+
 		dst := filepath.Join(destAppDir, relFromAppPath)
+		absDst, err := absClean(dst)
+		if err != nil {
+			return errors.Wrapf(err, "failed to resolve destination %q", dst)
+		}
+		if !isWithin(absDst, absDestDir) {
+			return fmt.Errorf("destination for %q escapes package dir", match)
+		}
+
 		if err := copyFile(match, dst); err != nil {
 			if !ignoreValuesFileCopyError(source, match, err) {
 				return errors.Wrapf(err, "failed to copy globbed value file %q", match)
@@ -51,4 +87,42 @@ func copyGlobValueFiles(srcAppPath, destAppDir string, source v1alpha1.Applicati
 		}
 	}
 	return nil
+}
+
+// resolveExisting returns an absolute, symlink-resolved path. The path must
+// exist on disk; this is used on the source side so symlinks planted inside
+// the repo cannot redirect us outside it.
+func resolveExisting(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.EvalSymlinks(abs)
+}
+
+// absClean returns the cleaned absolute form of path without resolving
+// symlinks. Used on the destination side, where the target path may not exist
+// yet and where we control the tree (so symlink redirection is not a concern).
+func absClean(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+// isWithin reports whether child is identical to parent or sits inside it.
+// Both arguments must be cleaned absolute paths.
+func isWithin(child, parent string) bool {
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	if rel == "." {
+		return true
+	}
+	if rel == ".." {
+		return false
+	}
+	return !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/pkg/argo_client/helm_values.go
+++ b/pkg/argo_client/helm_values.go
@@ -1,0 +1,54 @@
+package argo_client
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+// containsGlob reports whether the path includes glob meta-characters that
+// filepath.Glob would expand (*, ?, or a character class).
+func containsGlob(path string) bool {
+	return strings.ContainsAny(path, "*?[")
+}
+
+// copyGlobValueFiles expands a glob-style Helm value file path (resolved
+// relative to srcAppPath) and copies each matching file into destAppDir,
+// preserving its location relative to the source app directory. The original
+// glob entry is left in source.Helm.ValueFiles so the Argo CD repo server can
+// expand it once it receives the package.
+func copyGlobValueFiles(srcAppPath, destAppDir string, source v1alpha1.ApplicationSource, valueFile string) error {
+	pattern := filepath.Join(srcAppPath, valueFile)
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return errors.Wrapf(err, "failed to expand glob %q", valueFile)
+	}
+
+	if len(matches) == 0 {
+		if source.Helm != nil && source.Helm.IgnoreMissingValueFiles {
+			log.Debug().Caller().
+				Str("valueFile", valueFile).
+				Msg("glob value file matched no files, skipping (IgnoreMissingValueFiles is true)")
+			return nil
+		}
+		return fmt.Errorf("glob value file %q matched no files", valueFile)
+	}
+
+	for _, match := range matches {
+		relFromAppPath, err := filepath.Rel(srcAppPath, match)
+		if err != nil {
+			return errors.Wrapf(err, "failed to compute relative path for %q", match)
+		}
+		dst := filepath.Join(destAppDir, relFromAppPath)
+		if err := copyFile(match, dst); err != nil {
+			if !ignoreValuesFileCopyError(source, match, err) {
+				return errors.Wrapf(err, "failed to copy globbed value file %q", match)
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/argo_client/helm_values_test.go
+++ b/pkg/argo_client/helm_values_test.go
@@ -15,16 +15,21 @@ func TestContainsGlob(t *testing.T) {
 		path     string
 		expected bool
 	}{
-		"plain":            {"values.yaml", false},
-		"relative-plain":   {"./values.yaml", false},
-		"parent-plain":     {"../values.yaml", false},
-		"star":             {"./values-*.yaml", true},
-		"parent-star":      {"../values-*.yaml", true},
-		"question":         {"values-?.yaml", true},
-		"char-class":       {"values-[ab].yaml", true},
-		"empty":            {"", false},
-		"directory-glob":   {"envs/*/values.yaml", true},
-		"trailing-star":    {"values.yaml*", true},
+		"plain":              {"values.yaml", false},
+		"relative-plain":     {"./values.yaml", false},
+		"parent-plain":       {"../values.yaml", false},
+		"star":               {"./values-*.yaml", true},
+		"parent-star":        {"../values-*.yaml", true},
+		"question":           {"values-?.yaml", true},
+		"char-class":         {"values-[ab].yaml", true},
+		"empty":              {"", false},
+		"directory-glob":     {"envs/*/values.yaml", true},
+		"trailing-star":      {"values.yaml*", true},
+		"multi-wildcard":     {"./env-*/values-*.yaml", true},
+		"numeric-char-class": {"values-[0-9].yaml", true},
+		// Unclosed '[' is conservatively treated as a glob; filepath.Glob will
+		// return ErrBadPattern if expansion is attempted.
+		"unclosed-bracket": {"values-[ab.yaml", true},
 	}
 
 	for name, tc := range testcases {

--- a/pkg/argo_client/helm_values_test.go
+++ b/pkg/argo_client/helm_values_test.go
@@ -1,0 +1,158 @@
+package argo_client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainsGlob(t *testing.T) {
+	testcases := map[string]struct {
+		path     string
+		expected bool
+	}{
+		"plain":            {"values.yaml", false},
+		"relative-plain":   {"./values.yaml", false},
+		"parent-plain":     {"../values.yaml", false},
+		"star":             {"./values-*.yaml", true},
+		"parent-star":      {"../values-*.yaml", true},
+		"question":         {"values-?.yaml", true},
+		"char-class":       {"values-[ab].yaml", true},
+		"empty":            {"", false},
+		"directory-glob":   {"envs/*/values.yaml", true},
+		"trailing-star":    {"values.yaml*", true},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, containsGlob(tc.path))
+		})
+	}
+}
+
+func TestCopyGlobValueFiles(t *testing.T) {
+	// helper to lay out a fake repo structure under a temp dir
+	setup := func(t *testing.T, files map[string]string) (srcAppPath, destAppDir string) {
+		t.Helper()
+		root := t.TempDir()
+		srcAppPath = filepath.Join(root, "repo", "app1")
+		destAppDir = filepath.Join(root, "package", "app1")
+
+		require.NoError(t, os.MkdirAll(srcAppPath, 0o755))
+		require.NoError(t, os.MkdirAll(destAppDir, 0o755))
+
+		for relPath, content := range files {
+			full := filepath.Join(srcAppPath, relPath)
+			require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+			require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+		}
+		return srcAppPath, destAppDir
+	}
+
+	t.Run("expands glob within source path", func(t *testing.T) {
+		srcAppPath, destAppDir := setup(t, map[string]string{
+			"values-clusterA.yaml": "a",
+			"values-clusterB.yaml": "b",
+			"unrelated.yaml":       "c",
+		})
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{},
+		}
+		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./values-*.yaml")
+		require.NoError(t, err)
+
+		assertFileContent(t, filepath.Join(destAppDir, "values-clusterA.yaml"), "a")
+		assertFileContent(t, filepath.Join(destAppDir, "values-clusterB.yaml"), "b")
+		assertFileMissing(t, filepath.Join(destAppDir, "unrelated.yaml"))
+	})
+
+	t.Run("expands glob in sibling directory", func(t *testing.T) {
+		srcAppPath, destAppDir := setup(t, map[string]string{
+			"../shared/values-1.yaml": "one",
+			"../shared/values-2.yaml": "two",
+			"../shared/other.yaml":    "skip",
+		})
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{},
+		}
+		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "../shared/values-*.yaml")
+		require.NoError(t, err)
+
+		assertFileContent(t, filepath.Join(destAppDir, "../shared/values-1.yaml"), "one")
+		assertFileContent(t, filepath.Join(destAppDir, "../shared/values-2.yaml"), "two")
+		assertFileMissing(t, filepath.Join(destAppDir, "../shared/other.yaml"))
+	})
+
+	t.Run("no matches with IgnoreMissingValueFiles is not an error", func(t *testing.T) {
+		srcAppPath, destAppDir := setup(t, map[string]string{
+			"values.yaml": "x",
+		})
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{IgnoreMissingValueFiles: true},
+		}
+		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./missing-*.yaml")
+		require.NoError(t, err)
+	})
+
+	t.Run("no matches without IgnoreMissingValueFiles returns an error", func(t *testing.T) {
+		srcAppPath, destAppDir := setup(t, map[string]string{
+			"values.yaml": "x",
+		})
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{},
+		}
+		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./missing-*.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "matched no files")
+	})
+
+	t.Run("no matches with nil Helm returns an error", func(t *testing.T) {
+		srcAppPath, destAppDir := setup(t, map[string]string{
+			"values.yaml": "x",
+		})
+
+		source := v1alpha1.ApplicationSource{}
+		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./missing-*.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "matched no files")
+	})
+
+	t.Run("preserves nested directory layout", func(t *testing.T) {
+		srcAppPath, destAppDir := setup(t, map[string]string{
+			"envs/dev/values.yaml":     "dev",
+			"envs/staging/values.yaml": "staging",
+			"envs/dev/skip.txt":        "skip",
+		})
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{},
+		}
+		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./envs/*/values.yaml")
+		require.NoError(t, err)
+
+		assertFileContent(t, filepath.Join(destAppDir, "envs/dev/values.yaml"), "dev")
+		assertFileContent(t, filepath.Join(destAppDir, "envs/staging/values.yaml"), "staging")
+		assertFileMissing(t, filepath.Join(destAppDir, "envs/dev/skip.txt"))
+	})
+}
+
+func assertFileContent(t *testing.T, path, expected string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "expected file %s to exist", path)
+	assert.Equal(t, expected, string(data))
+}
+
+func assertFileMissing(t *testing.T, path string) {
+	t.Helper()
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "expected file %s to be missing", path)
+}

--- a/pkg/argo_client/helm_values_test.go
+++ b/pkg/argo_client/helm_values_test.go
@@ -36,11 +36,13 @@ func TestContainsGlob(t *testing.T) {
 
 func TestCopyGlobValueFiles(t *testing.T) {
 	// helper to lay out a fake repo structure under a temp dir
-	setup := func(t *testing.T, files map[string]string) (srcAppPath, destAppDir string) {
+	setup := func(t *testing.T, files map[string]string) (repoRoot, destDir, srcAppPath, destAppDir string) {
 		t.Helper()
 		root := t.TempDir()
-		srcAppPath = filepath.Join(root, "repo", "app1")
-		destAppDir = filepath.Join(root, "package", "app1")
+		repoRoot = filepath.Join(root, "repo")
+		destDir = filepath.Join(root, "package")
+		srcAppPath = filepath.Join(repoRoot, "app1")
+		destAppDir = filepath.Join(destDir, "app1")
 
 		require.NoError(t, os.MkdirAll(srcAppPath, 0o755))
 		require.NoError(t, os.MkdirAll(destAppDir, 0o755))
@@ -50,11 +52,11 @@ func TestCopyGlobValueFiles(t *testing.T) {
 			require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
 			require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
 		}
-		return srcAppPath, destAppDir
+		return repoRoot, destDir, srcAppPath, destAppDir
 	}
 
 	t.Run("expands glob within source path", func(t *testing.T) {
-		srcAppPath, destAppDir := setup(t, map[string]string{
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
 			"values-clusterA.yaml": "a",
 			"values-clusterB.yaml": "b",
 			"unrelated.yaml":       "c",
@@ -63,7 +65,7 @@ func TestCopyGlobValueFiles(t *testing.T) {
 		source := v1alpha1.ApplicationSource{
 			Helm: &v1alpha1.ApplicationSourceHelm{},
 		}
-		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./values-*.yaml")
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "./values-*.yaml")
 		require.NoError(t, err)
 
 		assertFileContent(t, filepath.Join(destAppDir, "values-clusterA.yaml"), "a")
@@ -72,7 +74,7 @@ func TestCopyGlobValueFiles(t *testing.T) {
 	})
 
 	t.Run("expands glob in sibling directory", func(t *testing.T) {
-		srcAppPath, destAppDir := setup(t, map[string]string{
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
 			"../shared/values-1.yaml": "one",
 			"../shared/values-2.yaml": "two",
 			"../shared/other.yaml":    "skip",
@@ -81,7 +83,7 @@ func TestCopyGlobValueFiles(t *testing.T) {
 		source := v1alpha1.ApplicationSource{
 			Helm: &v1alpha1.ApplicationSourceHelm{},
 		}
-		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "../shared/values-*.yaml")
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "../shared/values-*.yaml")
 		require.NoError(t, err)
 
 		assertFileContent(t, filepath.Join(destAppDir, "../shared/values-1.yaml"), "one")
@@ -90,43 +92,43 @@ func TestCopyGlobValueFiles(t *testing.T) {
 	})
 
 	t.Run("no matches with IgnoreMissingValueFiles is not an error", func(t *testing.T) {
-		srcAppPath, destAppDir := setup(t, map[string]string{
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
 			"values.yaml": "x",
 		})
 
 		source := v1alpha1.ApplicationSource{
 			Helm: &v1alpha1.ApplicationSourceHelm{IgnoreMissingValueFiles: true},
 		}
-		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./missing-*.yaml")
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "./missing-*.yaml")
 		require.NoError(t, err)
 	})
 
 	t.Run("no matches without IgnoreMissingValueFiles returns an error", func(t *testing.T) {
-		srcAppPath, destAppDir := setup(t, map[string]string{
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
 			"values.yaml": "x",
 		})
 
 		source := v1alpha1.ApplicationSource{
 			Helm: &v1alpha1.ApplicationSourceHelm{},
 		}
-		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./missing-*.yaml")
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "./missing-*.yaml")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "matched no files")
 	})
 
 	t.Run("no matches with nil Helm returns an error", func(t *testing.T) {
-		srcAppPath, destAppDir := setup(t, map[string]string{
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
 			"values.yaml": "x",
 		})
 
 		source := v1alpha1.ApplicationSource{}
-		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./missing-*.yaml")
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "./missing-*.yaml")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "matched no files")
 	})
 
 	t.Run("preserves nested directory layout", func(t *testing.T) {
-		srcAppPath, destAppDir := setup(t, map[string]string{
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
 			"envs/dev/values.yaml":     "dev",
 			"envs/staging/values.yaml": "staging",
 			"envs/dev/skip.txt":        "skip",
@@ -135,13 +137,114 @@ func TestCopyGlobValueFiles(t *testing.T) {
 		source := v1alpha1.ApplicationSource{
 			Helm: &v1alpha1.ApplicationSourceHelm{},
 		}
-		err := copyGlobValueFiles(srcAppPath, destAppDir, source, "./envs/*/values.yaml")
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "./envs/*/values.yaml")
 		require.NoError(t, err)
 
 		assertFileContent(t, filepath.Join(destAppDir, "envs/dev/values.yaml"), "dev")
 		assertFileContent(t, filepath.Join(destAppDir, "envs/staging/values.yaml"), "staging")
 		assertFileMissing(t, filepath.Join(destAppDir, "envs/dev/skip.txt"))
 	})
+
+	t.Run("absolute valueFile is rejected", func(t *testing.T) {
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
+			"values.yaml": "x",
+		})
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{IgnoreMissingValueFiles: true},
+		}
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "/etc/passwd")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute value file paths are not permitted")
+	})
+
+	t.Run("path traversal escaping repo root is rejected", func(t *testing.T) {
+		// Create a sensitive file outside the repo root, and a glob that
+		// would match it via ../ traversal.
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
+			"values.yaml": "x",
+		})
+		outside := filepath.Join(filepath.Dir(repoRoot), "secrets")
+		require.NoError(t, os.MkdirAll(outside, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(outside, "password.yaml"), []byte("secret"), 0o600))
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{},
+		}
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "../../secrets/*.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes repo root")
+	})
+
+	t.Run("symlinked match escaping repo root is rejected", func(t *testing.T) {
+		// Plant a symlink inside the repo that points to a file outside it.
+		repoRoot, destDir, srcAppPath, destAppDir := setup(t, map[string]string{
+			"values.yaml": "x",
+		})
+		outside := filepath.Join(filepath.Dir(repoRoot), "outside")
+		require.NoError(t, os.MkdirAll(outside, 0o755))
+		target := filepath.Join(outside, "evil.yaml")
+		require.NoError(t, os.WriteFile(target, []byte("evil"), 0o600))
+		linkPath := filepath.Join(srcAppPath, "values-evil.yaml")
+		require.NoError(t, os.Symlink(target, linkPath))
+
+		source := v1alpha1.ApplicationSource{
+			Helm: &v1alpha1.ApplicationSourceHelm{},
+		}
+		err := copyGlobValueFiles(repoRoot, destDir, srcAppPath, destAppDir, source, "./values-*.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "escapes repo root")
+	})
+}
+
+func TestAbsClean(t *testing.T) {
+	t.Run("cleans relative segments without resolving symlinks", func(t *testing.T) {
+		root := t.TempDir()
+		got, err := absClean(filepath.Join(root, "does", "..", "not", "exist"))
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(root, "not", "exist"), got)
+	})
+}
+
+func TestResolveExisting(t *testing.T) {
+	t.Run("evaluates symlinks for existing files", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(root, "real.txt")
+		require.NoError(t, os.WriteFile(target, []byte("x"), 0o600))
+		link := filepath.Join(root, "link.txt")
+		require.NoError(t, os.Symlink(target, link))
+
+		got, err := resolveExisting(link)
+		require.NoError(t, err)
+		// EvalSymlinks may resolve /var → /private/var on macOS; compare via
+		// the same resolution applied to the target.
+		expected, _ := filepath.EvalSymlinks(target)
+		assert.Equal(t, expected, got)
+	})
+
+	t.Run("returns an error for non-existent paths", func(t *testing.T) {
+		_, err := resolveExisting(filepath.Join(t.TempDir(), "missing"))
+		require.Error(t, err)
+	})
+}
+
+func TestIsWithin(t *testing.T) {
+	cases := map[string]struct {
+		child, parent string
+		expected      bool
+	}{
+		"identical":      {"/a/b", "/a/b", true},
+		"direct child":   {"/a/b/c", "/a/b", true},
+		"deep child":     {"/a/b/c/d/e", "/a/b", true},
+		"sibling":        {"/a/c", "/a/b", false},
+		"parent":         {"/a", "/a/b", false},
+		"prefix-but-not": {"/a/bc", "/a/b", false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isWithin(tc.child, tc.parent))
+		})
+	}
 }
 
 func assertFileContent(t *testing.T, path, expected string) {

--- a/pkg/argo_client/manifests.go
+++ b/pkg/argo_client/manifests.go
@@ -490,7 +490,7 @@ func packageApp(
 			}
 
 			if containsGlob(valueFile) {
-				if err := copyGlobValueFiles(srcAppPath, destAppDir, source, valueFile); err != nil {
+				if err := copyGlobValueFiles(repo.Directory, destDir, srcAppPath, destAppDir, source, valueFile); err != nil {
 					return "", err
 				}
 				continue

--- a/pkg/argo_client/manifests.go
+++ b/pkg/argo_client/manifests.go
@@ -489,6 +489,13 @@ func packageApp(
 				continue
 			}
 
+			if containsGlob(valueFile) {
+				if err := copyGlobValueFiles(srcAppPath, destAppDir, source, valueFile); err != nil {
+					return "", err
+				}
+				continue
+			}
+
 			relPath, err := filepath.Rel(source.Path, valueFile)
 			if err != nil {
 				return "", errors.Wrap(err, "failed to calculate relative path")

--- a/pkg/argo_client/manifests_test.go
+++ b/pkg/argo_client/manifests_test.go
@@ -390,6 +390,61 @@ resources:
 			},
 		},
 
+		"wildcard-value-files-are-expanded": {
+			pullRequest: vcs.PullRequest{
+				CloneURL: "git@github.com:testuser/testrepo.git",
+				BaseRef:  "main",
+				HeadRef:  "update-code",
+			},
+			app: v1alpha1.Application{
+				Spec: v1alpha1.ApplicationSpec{
+					Sources: []v1alpha1.ApplicationSource{
+						{
+							RepoURL:        "git@github.com:testuser/testrepo.git",
+							Path:           "app1/",
+							TargetRevision: "main",
+							Helm: &v1alpha1.ApplicationSourceHelm{
+								IgnoreMissingValueFiles: true,
+								ValueFiles: []string{
+									"./values.yaml",
+									"./values-*.yaml",
+									"../shared/values-*.yaml",
+									"./no-match-*.yaml",
+								},
+							},
+						},
+					},
+				},
+			},
+			filesByRepo: map[repoTarget]set[string]{
+				repoTarget{"git@github.com:testuser/testrepo.git", "main"}: newSet[string](
+					"app1/values.yaml",
+					"app1/values-clusterA.yaml",
+					"app1/values-clusterB.yaml",
+					"app1/unrelated.yaml",
+					"shared/values-shared-1.yaml",
+					"shared/values-shared-2.yaml",
+					"shared/other.yaml",
+				),
+			},
+			filesByRepoWithContent: map[repoTarget]map[string]string{
+				repoTarget{"git@github.com:testuser/testrepo.git", "main"}: {
+					"app1/Chart.yaml": `apiVersion: v2
+name: test-chart
+version: 1.0.0`,
+				},
+			},
+			expectedFiles: map[string]repoTargetPath{
+				"app1/Chart.yaml":            {"git@github.com:testuser/testrepo.git", "main", "app1/Chart.yaml"},
+				"app1/values.yaml":           {"git@github.com:testuser/testrepo.git", "main", "app1/values.yaml"},
+				"app1/values-clusterA.yaml":  {"git@github.com:testuser/testrepo.git", "main", "app1/values-clusterA.yaml"},
+				"app1/values-clusterB.yaml":  {"git@github.com:testuser/testrepo.git", "main", "app1/values-clusterB.yaml"},
+				"app1/unrelated.yaml":        {"git@github.com:testuser/testrepo.git", "main", "app1/unrelated.yaml"},
+				"shared/values-shared-1.yaml": {"git@github.com:testuser/testrepo.git", "main", "shared/values-shared-1.yaml"},
+				"shared/values-shared-2.yaml": {"git@github.com:testuser/testrepo.git", "main", "shared/values-shared-2.yaml"},
+			},
+		},
+
 		"helm-dependencies-are-copied": {
 			pullRequest: vcs.PullRequest{
 				CloneURL: "git@github.com:testuser/testrepo.git",


### PR DESCRIPTION
## Summary
- Argo CD 3.4 accepts glob-style entries in `source.helm.valueFiles` (e.g. `../values-*.yaml`), but kubechecks was treating those as literal filenames during packaging. With `IgnoreMissingValueFiles: true`, the matches were silently dropped from the tarball — the repo server would then have nothing to expand.
- `pkg/argo_client/packageApp` now detects glob meta-characters (`*`, `?`, `[`), expands them with `filepath.Glob` against the source app path, and copies each match into the package while preserving its relative location. The original glob entry is left in `ValueFiles` so Argo CD still does the canonical expansion at template time.
- New `pkg/argo_client/helm_values.go` keeps the helpers separate from the already-large `manifests.go`.

## Test plan
- [x] `go test ./pkg/argo_client/...`
- [x] New `TestContainsGlob` cases for plain paths, `*` / `?` / `[` patterns, parent-relative globs, nested globs
- [x] New `TestCopyGlobValueFiles` subtests:
  - glob within `srcAppPath` copies matches and ignores non-matches
  - sibling-directory glob (`../shared/values-*.yaml`) lands at the right relative path
  - no matches with `IgnoreMissingValueFiles: true` is not an error
  - no matches with `IgnoreMissingValueFiles: false` returns an error
  - no matches with `Helm: nil` returns an error
  - nested glob preserves directory layout
- [x] New `TestPackageApp/wildcard-value-files-are-expanded` exercises the packaging path end-to-end with both in-path and sibling-path globs alongside a non-matching glob

fix https://github.com/zapier/kubechecks/issues/515