### PR TITLE
feat(archive): retry download on transient failures, surface typed er…

### DIFF
--- a/pkg/archive/cache.go
+++ b/pkg/archive/cache.go
@@ -117,7 +117,6 @@ func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA st
 		const (
 			maxDownloadAttempts  = 3
 			downloadInitialDelay = 10 * time.Second
-			downloadMaxDelay     = 20 * time.Second // caps the 2nd+ sleep: 10s → 20s → 20s …
 		)
 		retryDelay := downloadInitialDelay
 		var lastErr error
@@ -144,9 +143,6 @@ func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA st
 					return nil, ctx.Err()
 				case <-time.After(retryDelay):
 					retryDelay *= 2
-					if retryDelay > downloadMaxDelay {
-						retryDelay = downloadMaxDelay
-					}
 				}
 			}
 

--- a/pkg/archive/cache.go
+++ b/pkg/archive/cache.go
@@ -72,135 +72,150 @@ func NewCache(cfg Config) *Cache {
 	return cache
 }
 
-// GetOrDownload retrieves a cached archive or downloads it if not present
-// Returns the path to the extracted archive directory
+// GetOrDownload retrieves a cached archive or downloads it if not present.
+// Returns the path to the extracted archive directory.
+//
+// Retry backoff runs outside the singleflight so callers with short-lived
+// contexts are not blocked during sleep intervals. Each attempt is its own
+// singleflight call — concurrent callers for the same SHA are still coalesced
+// per attempt, they just don't wait through each other's backoff windows.
 func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA string, authHeaders map[string]string) (string, error) {
+	// Fast path: check cache before entering the retry loop.
+	c.lock.RLock()
+	entry, exists := c.entries[mergeCommitSHA]
+	c.lock.RUnlock()
+	if exists {
+		archiveCacheHits.Inc()
+		atomic.AddInt32(&entry.refCount, 1)
+		entry.lastUsed = time.Now()
+		log.Debug().
+			Caller().
+			Str("archive_url", archiveURL).
+			Str("merge_commit_sha", mergeCommitSHA).
+			Str("path", entry.extractedPath).
+			Msg("using cached archive")
+		return entry.extractedPath, nil
+	}
 
-	// Use singleflight to prevent duplicate downloads for the same archive
-	result, err, _ := c.downloadGroup.Do(mergeCommitSHA, func() (interface{}, error) {
-		// Check if archive already exists in cache
-		c.lock.RLock()
-		entry, exists := c.entries[mergeCommitSHA]
-		c.lock.RUnlock()
+	archiveCacheMisses.Inc()
+	log.Info().
+		Str("archive_url", archiveURL).
+		Str("merge_commit_sha", mergeCommitSHA).
+		Msg("downloading archive to cache")
 
-		if exists {
-			// Cache hit - reuse existing archive
-			archiveCacheHits.Inc()
-			atomic.AddInt32(&entry.refCount, 1)
-			entry.lastUsed = time.Now()
+	// Using merge_commit_sha directly as it is globally unique.
+	targetDir := filepath.Join(c.baseDir, mergeCommitSHA)
 
-			log.Debug().
+	const (
+		maxDownloadAttempts  = 3
+		downloadInitialDelay = 10 * time.Second
+	)
+	retryDelay := downloadInitialDelay
+	var lastErr error
+
+	for attempt := 0; attempt < maxDownloadAttempts; attempt++ {
+		if attempt > 0 {
+			log.Info().
 				Caller().
 				Str("archive_url", archiveURL).
 				Str("merge_commit_sha", mergeCommitSHA).
-				Str("path", entry.extractedPath).
-				Msg("using cached archive")
+				Int("attempt", attempt+1).
+				Int("max_attempts", maxDownloadAttempts).
+				Dur("backoff", retryDelay).
+				Err(lastErr).
+				Msg("retrying archive download after transient failure")
 
-			return entry.extractedPath, nil
+			// Backoff outside singleflight — callers with expired contexts exit here
+			// rather than waiting through the full retry window.
+			select {
+			case <-ctx.Done():
+				return "", errors.Wrapf(ctx.Err(), "archive download retry interrupted after transient failure: %v", lastErr)
+			case <-time.After(retryDelay):
+				retryDelay *= 2
+			}
 		}
 
-		// Cache miss - need to download
-		archiveCacheMisses.Inc()
-
-		log.Info().
-			Str("archive_url", archiveURL).
-			Str("merge_commit_sha", mergeCommitSHA).
-			Msg("downloading archive to cache")
-
-		// Create target directory for this archive
-		// Using merge_commit_sha directly as it's globally unique
-		targetDir := filepath.Join(c.baseDir, mergeCommitSHA)
-
-		// Download with retry for transient failures (network hiccups, CDN lag, 5xx).
-		// Retry runs inside the singleflight so all concurrent callers for the same SHA
-		// share one retry chain instead of each making independent requests.
-		const (
-			maxDownloadAttempts  = 3
-			downloadInitialDelay = 10 * time.Second
-		)
-		retryDelay := downloadInitialDelay
-		var lastErr error
-
-		for attempt := 0; attempt < maxDownloadAttempts; attempt++ {
-			if attempt > 0 {
-				// Remove any partial extraction before retrying
-				if removeErr := os.RemoveAll(targetDir); removeErr != nil {
-					log.Warn().Err(removeErr).Str("dir", targetDir).Msg("failed to clean up partial archive directory before retry")
-				}
-
-				log.Info().
-					Caller().
-					Str("archive_url", archiveURL).
-					Str("merge_commit_sha", mergeCommitSHA).
-					Int("attempt", attempt+1).
-					Int("max_attempts", maxDownloadAttempts).
-					Dur("backoff", retryDelay).
-					Err(lastErr).
-					Msg("retrying archive download after transient failure")
-
-				select {
-				case <-ctx.Done():
-					return nil, errors.Wrapf(ctx.Err(), "archive download retry interrupted after transient failure: %v", lastErr)
-				case <-time.After(retryDelay):
-					retryDelay *= 2
-				}
+		start := time.Now()
+		result, err, shared := c.downloadGroup.Do(mergeCommitSHA, func() (interface{}, error) {
+			// Re-check cache — another caller may have populated it while we waited.
+			c.lock.RLock()
+			entry, exists := c.entries[mergeCommitSHA]
+			c.lock.RUnlock()
+			if exists {
+				archiveCacheHits.Inc()
+				atomic.AddInt32(&entry.refCount, 1)
+				entry.lastUsed = time.Now()
+				return entry.extractedPath, nil
 			}
 
-			var extractedPath string
-			extractedPath, lastErr = c.downloader.DownloadAndExtract(ctx, archiveURL, targetDir, authHeaders)
-			if lastErr == nil {
-				// Create cache entry
-				entry = &CacheEntry{
-					extractedPath: extractedPath,
-					lastUsed:      time.Now(),
-					refCount:      1,
-				}
-
-				// Add to cache
-				c.lock.Lock()
-				c.entries[mergeCommitSHA] = entry
-				c.lock.Unlock()
-
-				log.Info().
-					Str("archive_url", archiveURL).
-					Str("merge_commit_sha", mergeCommitSHA).
-					Str("path", extractedPath).
-					Msg("archive downloaded and cached")
-
-				return extractedPath, nil
+			// Remove any partial content left by a previous failed attempt.
+			// os.RemoveAll is a no-op when targetDir does not exist yet.
+			if removeErr := os.RemoveAll(targetDir); removeErr != nil {
+				log.Warn().Err(removeErr).Str("dir", targetDir).Msg("failed to clean up partial archive directory before download")
 			}
 
-			if !isRetriableDownloadError(ctx, lastErr) {
-				log.Debug().
-					Caller().
-					Err(lastErr).
-					Str("archive_url", archiveURL).
-					Msg("archive download error is not retriable")
-				break
+			extractedPath, err := c.downloader.DownloadAndExtract(ctx, archiveURL, targetDir, authHeaders)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to download and extract archive")
 			}
 
-			log.Warn().
+			entry = &CacheEntry{
+				extractedPath: extractedPath,
+				lastUsed:      time.Now(),
+				refCount:      1,
+			}
+			c.lock.Lock()
+			c.entries[mergeCommitSHA] = entry
+			c.lock.Unlock()
+
+			log.Info().
+				Str("archive_url", archiveURL).
+				Str("merge_commit_sha", mergeCommitSHA).
+				Str("path", extractedPath).
+				Msg("archive downloaded and cached")
+
+			return extractedPath, nil
+		})
+
+		if shared {
+			log.Info().
+				Caller().
+				Str("merge_commit_sha", mergeCommitSHA).
+				Dur("waited", time.Since(start)).
+				Bool("success", err == nil).
+				Msg("singleflight coalesced: caller waited on an in-flight archive download")
+		}
+
+		if err == nil {
+			return result.(string), nil
+		}
+
+		lastErr = err
+
+		if !isRetriableDownloadError(ctx, lastErr) {
+			log.Debug().
 				Caller().
 				Err(lastErr).
 				Str("archive_url", archiveURL).
-				Int("attempt", attempt+1).
-				Int("max_attempts", maxDownloadAttempts).
-				Msg("transient archive download failure")
+				Msg("archive download error is not retriable")
+			break
 		}
 
-		// Clean up any partial extraction left by the final failed attempt.
-		if removeErr := os.RemoveAll(targetDir); removeErr != nil {
-			log.Warn().Err(removeErr).Str("dir", targetDir).Msg("failed to clean up archive directory after failed download")
-		}
-
-		return nil, errors.Wrap(lastErr, "failed to download and extract archive")
-	})
-
-	if err != nil {
-		return "", err
+		log.Warn().
+			Caller().
+			Err(lastErr).
+			Str("archive_url", archiveURL).
+			Int("attempt", attempt+1).
+			Int("max_attempts", maxDownloadAttempts).
+			Msg("transient archive download failure")
 	}
 
-	return result.(string), nil
+	// Clean up any partial extraction left by the final failed attempt.
+	if removeErr := os.RemoveAll(targetDir); removeErr != nil {
+		log.Warn().Err(removeErr).Str("dir", targetDir).Msg("failed to clean up archive directory after failed download")
+	}
+
+	return "", errors.Wrap(lastErr, "failed to download and extract archive")
 }
 
 // Release decrements the reference count for an archive

--- a/pkg/archive/cache.go
+++ b/pkg/archive/cache.go
@@ -140,7 +140,7 @@ func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA st
 
 				select {
 				case <-ctx.Done():
-					return nil, ctx.Err()
+					return nil, errors.Wrapf(ctx.Err(), "archive download retry interrupted after transient failure: %v", lastErr)
 				case <-time.After(retryDelay):
 					retryDelay *= 2
 				}

--- a/pkg/archive/cache.go
+++ b/pkg/archive/cache.go
@@ -117,7 +117,7 @@ func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA st
 		const (
 			maxDownloadAttempts  = 3
 			downloadInitialDelay = 10 * time.Second
-			downloadMaxDelay     = 30 * time.Second
+			downloadMaxDelay     = 20 * time.Second // caps the 2nd+ sleep: 10s → 20s → 20s …
 		)
 		retryDelay := downloadInitialDelay
 		var lastErr error
@@ -190,6 +190,11 @@ func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA st
 				Int("attempt", attempt+1).
 				Int("max_attempts", maxDownloadAttempts).
 				Msg("transient archive download failure")
+		}
+
+		// Clean up any partial extraction left by the final failed attempt.
+		if removeErr := os.RemoveAll(targetDir); removeErr != nil {
+			log.Warn().Err(removeErr).Str("dir", targetDir).Msg("failed to clean up archive directory after failed download")
 		}
 
 		return nil, errors.Wrap(lastErr, "failed to download and extract archive")

--- a/pkg/archive/cache.go
+++ b/pkg/archive/cache.go
@@ -111,31 +111,88 @@ func (c *Cache) GetOrDownload(ctx context.Context, archiveURL, mergeCommitSHA st
 		// Using merge_commit_sha directly as it's globally unique
 		targetDir := filepath.Join(c.baseDir, mergeCommitSHA)
 
-		// Download and extract
-		extractedPath, err := c.downloader.DownloadAndExtract(ctx, archiveURL, targetDir, authHeaders)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to download and extract archive")
+		// Download with retry for transient failures (network hiccups, CDN lag, 5xx).
+		// Retry runs inside the singleflight so all concurrent callers for the same SHA
+		// share one retry chain instead of each making independent requests.
+		const (
+			maxDownloadAttempts  = 3
+			downloadInitialDelay = 10 * time.Second
+			downloadMaxDelay     = 30 * time.Second
+		)
+		retryDelay := downloadInitialDelay
+		var lastErr error
+
+		for attempt := 0; attempt < maxDownloadAttempts; attempt++ {
+			if attempt > 0 {
+				// Remove any partial extraction before retrying
+				if removeErr := os.RemoveAll(targetDir); removeErr != nil {
+					log.Warn().Err(removeErr).Str("dir", targetDir).Msg("failed to clean up partial archive directory before retry")
+				}
+
+				log.Info().
+					Caller().
+					Str("archive_url", archiveURL).
+					Str("merge_commit_sha", mergeCommitSHA).
+					Int("attempt", attempt+1).
+					Int("max_attempts", maxDownloadAttempts).
+					Dur("backoff", retryDelay).
+					Err(lastErr).
+					Msg("retrying archive download after transient failure")
+
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(retryDelay):
+					retryDelay *= 2
+					if retryDelay > downloadMaxDelay {
+						retryDelay = downloadMaxDelay
+					}
+				}
+			}
+
+			var extractedPath string
+			extractedPath, lastErr = c.downloader.DownloadAndExtract(ctx, archiveURL, targetDir, authHeaders)
+			if lastErr == nil {
+				// Create cache entry
+				entry = &CacheEntry{
+					extractedPath: extractedPath,
+					lastUsed:      time.Now(),
+					refCount:      1,
+				}
+
+				// Add to cache
+				c.lock.Lock()
+				c.entries[mergeCommitSHA] = entry
+				c.lock.Unlock()
+
+				log.Info().
+					Str("archive_url", archiveURL).
+					Str("merge_commit_sha", mergeCommitSHA).
+					Str("path", extractedPath).
+					Msg("archive downloaded and cached")
+
+				return extractedPath, nil
+			}
+
+			if !isRetriableDownloadError(ctx, lastErr) {
+				log.Debug().
+					Caller().
+					Err(lastErr).
+					Str("archive_url", archiveURL).
+					Msg("archive download error is not retriable")
+				break
+			}
+
+			log.Warn().
+				Caller().
+				Err(lastErr).
+				Str("archive_url", archiveURL).
+				Int("attempt", attempt+1).
+				Int("max_attempts", maxDownloadAttempts).
+				Msg("transient archive download failure")
 		}
 
-		// Create cache entry
-		entry = &CacheEntry{
-			extractedPath: extractedPath,
-			lastUsed:      time.Now(),
-			refCount:      1,
-		}
-
-		// Add to cache
-		c.lock.Lock()
-		c.entries[mergeCommitSHA] = entry
-		c.lock.Unlock()
-
-		log.Info().
-			Str("archive_url", archiveURL).
-			Str("merge_commit_sha", mergeCommitSHA).
-			Str("path", extractedPath).
-			Msg("archive downloaded and cached")
-
-		return extractedPath, nil
+		return nil, errors.Wrap(lastErr, "failed to download and extract archive")
 	})
 
 	if err != nil {

--- a/pkg/archive/download.go
+++ b/pkg/archive/download.go
@@ -57,7 +57,9 @@ func (d *Downloader) DownloadAndExtract(ctx context.Context, archiveURL, targetD
 		return "", errors.Wrap(err, "failed to download archive")
 	}
 
-	// Extract archive
+	// Extract archive.
+	// Note: extract() does not take a context — cancellation during extraction (a local
+	// disk operation) is not supported and will run to completion regardless of ctx state.
 	extractedPath, err := d.extract(zipData, targetDir)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to extract archive")

--- a/pkg/archive/download.go
+++ b/pkg/archive/download.go
@@ -17,6 +17,8 @@ import (
 
 // HTTPError is returned when the archive server responds with a non-200 status code.
 // It carries the status code so callers can make retry decisions without string parsing.
+// Note: Body contains the raw response snippet and may include sensitive server data —
+// it is intentionally kept out of user-facing PR comments and used only in internal logs.
 type HTTPError struct {
 	StatusCode int
 	URL        string
@@ -27,6 +29,14 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("HTTP %d %s - URL: %s - Response: %s",
 		e.StatusCode, http.StatusText(e.StatusCode), e.URL, e.Body)
 }
+
+// extractError wraps failures that occur during local zip extraction.
+// These are never retriable — retrying the download won't fix zip corruption,
+// path traversal violations, permission errors, or out-of-disk-space conditions.
+type extractError struct{ err error }
+
+func (e *extractError) Error() string { return e.err.Error() }
+func (e *extractError) Unwrap() error { return e.err }
 
 // Downloader handles downloading and extracting archives
 type Downloader struct {
@@ -60,9 +70,11 @@ func (d *Downloader) DownloadAndExtract(ctx context.Context, archiveURL, targetD
 	// Extract archive.
 	// Note: extract() does not take a context — cancellation during extraction (a local
 	// disk operation) is not supported and will run to completion regardless of ctx state.
+	// Extraction failures are wrapped in extractError so isRetriableDownloadError can
+	// distinguish them from transient download failures and skip retries.
 	extractedPath, err := d.extract(zipData, targetDir)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to extract archive")
+		return "", &extractError{err: errors.Wrap(err, "failed to extract archive")}
 	}
 
 	log.Info().
@@ -246,6 +258,12 @@ func (d *Downloader) extract(zipData []byte, targetDir string) (string, error) {
 // Returns false for context cancellation, permanent HTTP errors (4xx except 404/429), or nil.
 func isRetriableDownloadError(ctx context.Context, err error) bool {
 	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	// Local extraction failures (zip corruption, path traversal, disk full, permissions) are
+	// never transient — the same archive would produce the same failure on retry.
+	var extErr *extractError
+	if errors.As(err, &extErr) {
 		return false
 	}
 	var httpErr *HTTPError

--- a/pkg/archive/download.go
+++ b/pkg/archive/download.go
@@ -15,6 +15,19 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+// HTTPError is returned when the archive server responds with a non-200 status code.
+// It carries the status code so callers can make retry decisions without string parsing.
+type HTTPError struct {
+	StatusCode int
+	URL        string
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d %s - URL: %s - Response: %s",
+		e.StatusCode, http.StatusText(e.StatusCode), e.URL, e.Body)
+}
+
 // Downloader handles downloading and extracting archives
 type Downloader struct {
 	httpClient *http.Client
@@ -119,13 +132,11 @@ func (d *Downloader) download(ctx context.Context, archiveURL string, authHeader
 	// Check status code
 	if resp.StatusCode != http.StatusOK {
 		archiveDownloadFailed.Inc()
-		// Include response body snippet in error for debugging (first 500 chars)
 		bodySnippet := string(data)
 		if len(bodySnippet) > 500 {
 			bodySnippet = bodySnippet[:500] + "..."
 		}
-		return nil, fmt.Errorf("HTTP %d %s - URL: %s - Response: %s",
-			resp.StatusCode, http.StatusText(resp.StatusCode), archiveURL, bodySnippet)
+		return nil, &HTTPError{StatusCode: resp.StatusCode, URL: archiveURL, Body: bodySnippet}
 	}
 
 	archiveDownloadSuccess.Inc()
@@ -227,6 +238,24 @@ func (d *Downloader) extract(zipData []byte, targetDir string) (string, error) {
 		return filepath.Join(targetDir, topLevelDir), nil
 	}
 	return targetDir, nil
+}
+
+// isRetriableDownloadError returns true if the error is transient and the download should be retried.
+// Returns false for context cancellation, permanent HTTP errors (4xx except 404/429), or nil.
+func isRetriableDownloadError(ctx context.Context, err error) bool {
+	if err == nil || ctx.Err() != nil {
+		return false
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		sc := httpErr.StatusCode
+		// 404: archive may not be ready on CDN yet; 429: rate limited; 5xx: transient server errors
+		return sc == http.StatusNotFound ||
+			sc == http.StatusTooManyRequests ||
+			sc >= http.StatusInternalServerError
+	}
+	// Non-HTTP errors are network-level failures (connection refused, timeouts) — transient
+	return true
 }
 
 // extractFile extracts a single file from zip archive

--- a/pkg/archive/download_test.go
+++ b/pkg/archive/download_test.go
@@ -1,0 +1,125 @@
+package archive
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsRetriableDownloadError(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			ctx:  context.Background(),
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "context cancelled",
+			ctx:  cancelledCtx,
+			err:  fmt.Errorf("some error"),
+			want: false,
+		},
+		// HTTPError — retriable codes
+		{
+			name: "HTTP 404 not found",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusNotFound},
+			want: true,
+		},
+		{
+			name: "HTTP 429 rate limited",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusTooManyRequests},
+			want: true,
+		},
+		{
+			name: "HTTP 500 internal server error",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusInternalServerError},
+			want: true,
+		},
+		{
+			name: "HTTP 502 bad gateway",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusBadGateway},
+			want: true,
+		},
+		{
+			name: "HTTP 503 service unavailable",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusServiceUnavailable},
+			want: true,
+		},
+		// HTTPError — permanent codes
+		{
+			name: "HTTP 400 bad request",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusBadRequest},
+			want: false,
+		},
+		{
+			name: "HTTP 401 unauthorized",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusUnauthorized},
+			want: false,
+		},
+		{
+			name: "HTTP 403 forbidden",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusForbidden},
+			want: false,
+		},
+		{
+			name: "HTTP 422 unprocessable entity",
+			ctx:  context.Background(),
+			err:  &HTTPError{StatusCode: http.StatusUnprocessableEntity},
+			want: false,
+		},
+		// Wrapped HTTPError — errors.As must traverse the chain
+		{
+			name: "wrapped HTTP 503",
+			ctx:  context.Background(),
+			err:  errors.Wrap(&HTTPError{StatusCode: http.StatusServiceUnavailable}, "download failed"),
+			want: true,
+		},
+		{
+			name: "wrapped HTTP 403",
+			ctx:  context.Background(),
+			err:  errors.Wrap(&HTTPError{StatusCode: http.StatusForbidden}, "download failed"),
+			want: false,
+		},
+		// Non-HTTP errors are network-level — retriable
+		{
+			name: "generic network error",
+			ctx:  context.Background(),
+			err:  fmt.Errorf("connection refused"),
+			want: true,
+		},
+		{
+			name: "EOF error",
+			ctx:  context.Background(),
+			err:  fmt.Errorf("unexpected EOF"),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isRetriableDownloadError(tt.ctx, tt.err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/archive/download_test.go
+++ b/pkg/archive/download_test.go
@@ -114,6 +114,19 @@ func TestIsRetriableDownloadError(t *testing.T) {
 			err:  fmt.Errorf("unexpected EOF"),
 			want: true,
 		},
+		// extractError is always permanent — zip corruption/path traversal/disk full won't be fixed by retry
+		{
+			name: "extract error",
+			ctx:  context.Background(),
+			err:  &extractError{err: fmt.Errorf("invalid file path (path traversal detected): ../../etc/passwd")},
+			want: false,
+		},
+		{
+			name: "wrapped extract error",
+			ctx:  context.Background(),
+			err:  errors.Wrap(&extractError{err: fmt.Errorf("no space left on device")}, "failed to extract archive"),
+			want: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/archive/manager.go
+++ b/pkg/archive/manager.go
@@ -246,7 +246,17 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 		message = "⚠️ Kubechecks could not parse the archive URL returned by the VCS.\n\n" +
 			"This is likely a configuration or VCS compatibility issue — check the kubechecks logs."
 
+	case hasHTTP && httpErr.StatusCode >= 400 && httpErr.StatusCode < 500:
+		// Any remaining 4xx not handled above (400, 405, 410, 422, etc.) is a permanent
+		// client error — retrying via replan won't change the outcome.
+		message = fmt.Sprintf(
+			"⚠️ Failed to download the repository archive (HTTP %d %s).\n\n"+
+				"This is a permanent error. Check the kubechecks logs for details.",
+			httpErr.StatusCode, http.StatusText(httpErr.StatusCode),
+		)
+
 	case hasHTTP:
+		// Unexpected non-4xx, non-5xx response (e.g. 3xx not followed as redirect).
 		message = fmt.Sprintf(
 			"⚠️ Failed to download the repository archive (HTTP %d %s).\n\n"+
 				"Comment `%s` to retry.",

--- a/pkg/archive/manager.go
+++ b/pkg/archive/manager.go
@@ -189,21 +189,26 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 	var httpErr *HTTPError
 	hasHTTP := errors.As(cloneErr, &httpErr)
 
+	// Shared message strings — used in both the cloneErr branch and the ctx.Err() fallback
+	// so that wording stays consistent if either is ever updated.
+	timedOutMsg := fmt.Sprintf(
+		"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
+			"The VCS may still be computing the merge result. Comment `%s` to retry.",
+		replan,
+	)
+	interruptedMsg := fmt.Sprintf(
+		"⚠️ The archive download was interrupted before completing.\n\n"+
+			"This is usually caused by a shutdown or restart. Comment `%s` to retry.",
+		replan,
+	)
+
 	var message string
 	switch {
 	case errors.Is(cloneErr, context.DeadlineExceeded):
-		message = fmt.Sprintf(
-			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
-				"The VCS may still be computing the merge result. Comment `%s` to retry.",
-			replan,
-		)
+		message = timedOutMsg
 
 	case errors.Is(cloneErr, context.Canceled):
-		message = fmt.Sprintf(
-			"⚠️ The archive download was interrupted before completing.\n\n"+
-				"This is usually caused by a shutdown or restart. Comment `%s` to retry.",
-			replan,
-		)
+		message = interruptedMsg
 
 	case hasHTTP && httpErr.StatusCode == http.StatusNotFound:
 		message = fmt.Sprintf(
@@ -249,18 +254,10 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 		)
 
 	case errors.Is(ctx.Err(), context.DeadlineExceeded):
-		message = fmt.Sprintf(
-			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
-				"The VCS may still be computing the merge result. Comment `%s` to retry.",
-			replan,
-		)
+		message = timedOutMsg
 
 	case ctx.Err() != nil:
-		message = fmt.Sprintf(
-			"⚠️ The archive download was interrupted before completing.\n\n"+
-				"This is usually caused by a shutdown or restart. Comment `%s` to retry.",
-			replan,
-		)
+		message = interruptedMsg
 
 	default:
 		message = fmt.Sprintf(

--- a/pkg/archive/manager.go
+++ b/pkg/archive/manager.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"strings"
 
@@ -164,6 +165,77 @@ func (m *Manager) PostConflictMessage(ctx context.Context, pr vcs.PullRequest) e
 		Str("repo", pr.FullName).
 		Int("pr_number", pr.CheckID).
 		Msg("posted conflict resolution message")
+
+	return nil
+}
+
+// PostArchiveErrorMessage posts a specific error message to the PR based on the type of download failure.
+// If the original context is already cancelled (e.g. timeout), a background context is used so the
+// message can still be delivered.
+func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullRequest, cloneErr error) error {
+	replan := m.cfg.ReplanCommentMessage
+
+	var message string
+	var httpErr *HTTPError
+	switch {
+	case ctx.Err() != nil:
+		message = fmt.Sprintf(
+			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
+				"The VCS may still be computing the merge result. Comment `%s` to retry.",
+			replan,
+		)
+
+	case errors.As(cloneErr, &httpErr) && httpErr.StatusCode == http.StatusNotFound:
+		message = fmt.Sprintf(
+			"⚠️ Repository archive not found (HTTP 404).\n\n"+
+				"The VCS may still be preparing the merged archive. Comment `%s` to retry.",
+			replan,
+		)
+
+	case errors.As(cloneErr, &httpErr) && httpErr.StatusCode == http.StatusTooManyRequests:
+		message = fmt.Sprintf(
+			"⚠️ Rate limited while downloading the repository archive (HTTP 429).\n\n"+
+				"Comment `%s` to retry.",
+			replan,
+		)
+
+	case errors.As(cloneErr, &httpErr) && httpErr.StatusCode >= http.StatusInternalServerError:
+		message = fmt.Sprintf(
+			"⚠️ VCS server error while downloading the repository archive (HTTP %d %s).\n\n"+
+				"The VCS may be experiencing issues. Comment `%s` to retry.",
+			httpErr.StatusCode, http.StatusText(httpErr.StatusCode), replan,
+		)
+
+	case errors.As(cloneErr, &httpErr):
+		message = fmt.Sprintf(
+			"⚠️ Failed to download the repository archive (HTTP %d %s).\n\n"+
+				"Comment `%s` to retry.",
+			httpErr.StatusCode, http.StatusText(httpErr.StatusCode), replan,
+		)
+
+	default:
+		message = fmt.Sprintf(
+			"⚠️ Failed to download the repository archive due to a transient error.\n\n"+
+				"Comment `%s` to retry.",
+			replan,
+		)
+	}
+
+	// Use a fresh context if the original was cancelled so the message is still delivered.
+	postCtx := ctx
+	if ctx.Err() != nil {
+		postCtx = context.Background()
+	}
+
+	_, err := m.vcsClient.PostMessage(postCtx, pr, message)
+	if err != nil {
+		return errors.Wrap(err, "failed to post archive error message")
+	}
+
+	log.Info().
+		Str("repo", pr.FullName).
+		Int("pr_number", pr.CheckID).
+		Msg("posted archive download error message")
 
 	return nil
 }

--- a/pkg/archive/manager.go
+++ b/pkg/archive/manager.go
@@ -175,42 +175,61 @@ func (m *Manager) PostConflictMessage(ctx context.Context, pr vcs.PullRequest) e
 func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullRequest, cloneErr error) error {
 	replan := m.cfg.ReplanCommentMessage
 
-	var message string
+	// Classify by the error itself first; ctx.Err() is a fallback for cases where the
+	// context was cancelled for an unrelated reason after Clone returned.
 	var httpErr *HTTPError
+	hasHTTP := errors.As(cloneErr, &httpErr)
+
+	var message string
 	switch {
-	case ctx.Err() != nil:
+	case errors.Is(cloneErr, context.DeadlineExceeded) || errors.Is(cloneErr, context.Canceled):
 		message = fmt.Sprintf(
 			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
 				"The VCS may still be computing the merge result. Comment `%s` to retry.",
 			replan,
 		)
 
-	case errors.As(cloneErr, &httpErr) && httpErr.StatusCode == http.StatusNotFound:
+	case hasHTTP && httpErr.StatusCode == http.StatusNotFound:
 		message = fmt.Sprintf(
 			"⚠️ Repository archive not found (HTTP 404).\n\n"+
 				"The VCS may still be preparing the merged archive. Comment `%s` to retry.",
 			replan,
 		)
 
-	case errors.As(cloneErr, &httpErr) && httpErr.StatusCode == http.StatusTooManyRequests:
+	case hasHTTP && httpErr.StatusCode == http.StatusTooManyRequests:
 		message = fmt.Sprintf(
 			"⚠️ Rate limited while downloading the repository archive (HTTP 429).\n\n"+
 				"Comment `%s` to retry.",
 			replan,
 		)
 
-	case errors.As(cloneErr, &httpErr) && httpErr.StatusCode >= http.StatusInternalServerError:
+	case hasHTTP && httpErr.StatusCode >= http.StatusInternalServerError:
 		message = fmt.Sprintf(
 			"⚠️ VCS server error while downloading the repository archive (HTTP %d %s).\n\n"+
 				"The VCS may be experiencing issues. Comment `%s` to retry.",
 			httpErr.StatusCode, http.StatusText(httpErr.StatusCode), replan,
 		)
 
-	case errors.As(cloneErr, &httpErr):
+	case hasHTTP && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden):
+		// Permanent auth failure — retrying won't help; direct the user to fix credentials instead.
+		message = fmt.Sprintf(
+			"⚠️ Authorization error downloading the repository archive (HTTP %d %s).\n\n"+
+				"Check that kubechecks has the correct VCS credentials configured.",
+			httpErr.StatusCode, http.StatusText(httpErr.StatusCode),
+		)
+
+	case hasHTTP:
 		message = fmt.Sprintf(
 			"⚠️ Failed to download the repository archive (HTTP %d %s).\n\n"+
 				"Comment `%s` to retry.",
 			httpErr.StatusCode, http.StatusText(httpErr.StatusCode), replan,
+		)
+
+	case ctx.Err() != nil:
+		message = fmt.Sprintf(
+			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
+				"The VCS may still be computing the merge result. Comment `%s` to retry.",
+			replan,
 		)
 
 	default:

--- a/pkg/archive/manager.go
+++ b/pkg/archive/manager.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -182,10 +183,17 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 
 	var message string
 	switch {
-	case errors.Is(cloneErr, context.DeadlineExceeded) || errors.Is(cloneErr, context.Canceled):
+	case errors.Is(cloneErr, context.DeadlineExceeded):
 		message = fmt.Sprintf(
 			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
 				"The VCS may still be computing the merge result. Comment `%s` to retry.",
+			replan,
+		)
+
+	case errors.Is(cloneErr, context.Canceled):
+		message = fmt.Sprintf(
+			"⚠️ The archive download was interrupted before completing.\n\n"+
+				"This is usually caused by a shutdown or restart. Comment `%s` to retry.",
 			replan,
 		)
 
@@ -225,10 +233,17 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 			httpErr.StatusCode, http.StatusText(httpErr.StatusCode), replan,
 		)
 
-	case ctx.Err() != nil:
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
 		message = fmt.Sprintf(
 			"⚠️ Kubechecks timed out waiting for the repository archive to be ready.\n\n"+
 				"The VCS may still be computing the merge result. Comment `%s` to retry.",
+			replan,
+		)
+
+	case ctx.Err() != nil:
+		message = fmt.Sprintf(
+			"⚠️ The archive download was interrupted before completing.\n\n"+
+				"This is usually caused by a shutdown or restart. Comment `%s` to retry.",
 			replan,
 		)
 
@@ -241,9 +256,12 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 	}
 
 	// Use a fresh context if the original was cancelled so the message is still delivered.
+	// A 30s timeout bounds the fallback — a hung VCS should not leak this goroutine indefinitely.
 	postCtx := ctx
 	if ctx.Err() != nil {
-		postCtx = context.Background()
+		var cancel context.CancelFunc
+		postCtx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 	}
 
 	_, err := m.vcsClient.PostMessage(postCtx, pr, message)

--- a/pkg/archive/manager.go
+++ b/pkg/archive/manager.go
@@ -16,6 +16,13 @@ import (
 	"github.com/zapier/kubechecks/pkg/vcs"
 )
 
+// urlParseError wraps failures from extractSHAFromArchiveURL. These are permanent —
+// the archive URL format is unrecognized and retrying won't help.
+type urlParseError struct{ err error }
+
+func (e *urlParseError) Error() string { return e.err.Error() }
+func (e *urlParseError) Unwrap() error { return e.err }
+
 // Manager manages archive-based repository access
 // It provides a similar interface to git.RepoManager but uses VCS archives instead
 type Manager struct {
@@ -60,7 +67,7 @@ func (m *Manager) Clone(ctx context.Context, cloneURL, branchName string, pr vcs
 	// Otherwise, cache returns stale archives when new commits are pushed to existing PR
 	mergeCommitSHA, err := extractSHAFromArchiveURL(archiveURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to extract merge commit SHA from archive URL")
+		return nil, &urlParseError{err: errors.Wrap(err, "failed to extract merge commit SHA from archive URL")}
 	}
 
 	log.Debug().
@@ -178,6 +185,7 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 
 	// Classify by the error itself first; ctx.Err() is a fallback for cases where the
 	// context was cancelled for an unrelated reason after Clone returned.
+	var urlErr *urlParseError
 	var httpErr *HTTPError
 	hasHTTP := errors.As(cloneErr, &httpErr)
 
@@ -218,13 +226,20 @@ func (m *Manager) PostArchiveErrorMessage(ctx context.Context, pr vcs.PullReques
 			httpErr.StatusCode, http.StatusText(httpErr.StatusCode), replan,
 		)
 
-	case hasHTTP && (httpErr.StatusCode == http.StatusUnauthorized || httpErr.StatusCode == http.StatusForbidden):
-		// Permanent auth failure — retrying won't help; direct the user to fix credentials instead.
-		message = fmt.Sprintf(
-			"⚠️ Authorization error downloading the repository archive (HTTP %d %s).\n\n"+
-				"Check that kubechecks has the correct VCS credentials configured.",
-			httpErr.StatusCode, http.StatusText(httpErr.StatusCode),
-		)
+	case hasHTTP && httpErr.StatusCode == http.StatusUnauthorized:
+		// 401 = authentication failure (missing or invalid token)
+		message = "⚠️ Authentication failed downloading the repository archive (HTTP 401 Unauthorized).\n\n" +
+			"Check that kubechecks has a valid VCS token configured."
+
+	case hasHTTP && httpErr.StatusCode == http.StatusForbidden:
+		// 403 = authorization failure (token valid but lacks required scope/permissions)
+		message = "⚠️ Access denied downloading the repository archive (HTTP 403 Forbidden).\n\n" +
+			"Check that the kubechecks VCS token has sufficient repository permissions."
+
+	case errors.As(cloneErr, &urlErr):
+		// Unrecognized archive URL format — this is a bug, not something the user can retry
+		message = "⚠️ Kubechecks could not parse the archive URL returned by the VCS.\n\n" +
+			"This is likely a configuration or VCS compatibility issue — check the kubechecks logs."
 
 	case hasHTTP:
 		message = fmt.Sprintf(

--- a/pkg/archive/manager_sha_test.go
+++ b/pkg/archive/manager_sha_test.go
@@ -1,0 +1,91 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractSHAFromArchiveURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantSHA string
+		wantErr bool
+	}{
+		// GitHub formats
+		{
+			name:    "GitHub zip",
+			url:     "https://github.com/zapier/kubechecks/archive/abc123def456.zip",
+			wantSHA: "abc123def456",
+		},
+		{
+			name:    "GitHub Enterprise",
+			url:     "https://github.example.com/zapier/kubechecks/archive/abc123def456.zip",
+			wantSHA: "abc123def456",
+		},
+		{
+			name:    "GitHub full SHA",
+			url:     "https://github.com/owner/repo/archive/a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2.zip",
+			wantSHA: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+		},
+
+		// GitLab formats
+		{
+			name:    "GitLab sha as first query param",
+			url:     "https://gitlab.com/api/v4/projects/zapier%2Fkubechecks/repository/archive.zip?sha=abc123def456",
+			wantSHA: "abc123def456",
+		},
+		{
+			name:    "GitLab sha with trailing query params",
+			url:     "https://gitlab.com/api/v4/projects/zapier%2Fkubechecks/repository/archive.zip?sha=abc123def456&path=some/path",
+			wantSHA: "abc123def456",
+		},
+		{
+			name:    "GitLab sha as non-first query param",
+			url:     "https://gitlab.com/api/v4/projects/zapier%2Fkubechecks/repository/archive.zip?format=zip&sha=abc123def456",
+			wantSHA: "abc123def456",
+		},
+		{
+			name:    "GitLab self-hosted",
+			url:     "https://gitlab.example.com/api/v4/projects/group%2Frepo/repository/archive.zip?sha=deadbeef",
+			wantSHA: "deadbeef",
+		},
+
+		// Error cases
+		{
+			name:    "unrecognized URL format",
+			url:     "https://example.com/repo/download/abc123.zip",
+			wantErr: true,
+		},
+		{
+			name:    "empty URL",
+			url:     "",
+			wantErr: true,
+		},
+		{
+			name:    "GitHub archive URL with no filename after slash",
+			url:     "https://github.com/owner/repo/archive/",
+			wantErr: true,
+		},
+		{
+			name:    "GitLab URL with empty sha param",
+			url:     "https://gitlab.com/api/v4/projects/group%2Frepo/repository/archive.zip?sha=",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sha, err := extractSHAFromArchiveURL(tt.url)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Empty(t, sha)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantSHA, sha)
+			}
+		})
+	}
+}

--- a/pkg/archive/manager_test.go
+++ b/pkg/archive/manager_test.go
@@ -1,0 +1,113 @@
+package archive
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	vcsmocks "github.com/zapier/kubechecks/mocks/vcs/mocks"
+	"github.com/zapier/kubechecks/pkg/config"
+	"github.com/zapier/kubechecks/pkg/vcs"
+)
+
+func newTestManager(_ *testing.T, mockClient *vcsmocks.MockClient) *Manager {
+	return &Manager{
+		vcsClient: mockClient,
+		cfg:       config.ServerConfig{ReplanCommentMessage: "kubechecks replan"},
+	}
+}
+
+func TestPostArchiveErrorMessage(t *testing.T) {
+	pr := vcs.PullRequest{FullName: "org/repo", CheckID: 42, BaseRef: "main"}
+
+	tests := []struct {
+		name            string
+		ctx             func() context.Context
+		cloneErr        error
+		wantMsgContains []string
+	}{
+		{
+			name: "context timeout",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			cloneErr:        fmt.Errorf("deadline exceeded"),
+			wantMsgContains: []string{"timed out", "kubechecks replan"},
+		},
+		{
+			name:            "HTTP 404 not found",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &HTTPError{StatusCode: http.StatusNotFound},
+			wantMsgContains: []string{"404", "kubechecks replan"},
+		},
+		{
+			name:            "HTTP 429 rate limited",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &HTTPError{StatusCode: http.StatusTooManyRequests},
+			wantMsgContains: []string{"429", "kubechecks replan"},
+		},
+		{
+			name:            "HTTP 503 server error",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &HTTPError{StatusCode: http.StatusServiceUnavailable},
+			wantMsgContains: []string{"503", "Service Unavailable", "kubechecks replan"},
+		},
+		{
+			name:            "HTTP 403 other 4xx",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &HTTPError{StatusCode: http.StatusForbidden},
+			wantMsgContains: []string{"403", "Forbidden", "kubechecks replan"},
+		},
+		{
+			name:            "wrapped HTTP 502",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        errors.Wrap(&HTTPError{StatusCode: http.StatusBadGateway}, "failed to download"),
+			wantMsgContains: []string{"502", "kubechecks replan"},
+		},
+		{
+			name:            "generic network error",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        fmt.Errorf("connection refused"),
+			wantMsgContains: []string{"transient error", "kubechecks replan"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := vcsmocks.NewMockClient(t)
+			mockClient.On("PostMessage", mock.Anything, pr, mock.AnythingOfType("string")).
+				Return(nil, nil)
+
+			m := newTestManager(t, mockClient)
+			ctx := tt.ctx()
+
+			err := m.PostArchiveErrorMessage(ctx, pr, tt.cloneErr)
+			assert.NoError(t, err)
+
+			// Capture the posted message and assert it contains expected substrings
+			calls := mockClient.Calls
+			assert.Len(t, calls, 1, "expected exactly one PostMessage call")
+			postedMsg := calls[0].Arguments.String(2)
+			for _, want := range tt.wantMsgContains {
+				assert.Contains(t, postedMsg, want)
+			}
+		})
+	}
+
+	t.Run("PostMessage failure propagates error", func(t *testing.T) {
+		mockClient := vcsmocks.NewMockClient(t)
+		mockClient.On("PostMessage", mock.Anything, pr, mock.AnythingOfType("string")).
+			Return(nil, fmt.Errorf("vcs unavailable"))
+
+		m := newTestManager(t, mockClient)
+		err := m.PostArchiveErrorMessage(context.Background(), pr, fmt.Errorf("network error"))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "vcs unavailable")
+	})
+}

--- a/pkg/archive/manager_test.go
+++ b/pkg/archive/manager_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zapier/kubechecks/pkg/vcs"
 )
 
-func newTestManager(_ *testing.T, mockClient *vcsmocks.MockClient) *Manager {
+func newTestManager(mockClient *vcsmocks.MockClient) *Manager {
 	return &Manager{
 		vcsClient: mockClient,
 		cfg:       config.ServerConfig{ReplanCommentMessage: "kubechecks replan"},
@@ -29,15 +29,41 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 		ctx             func() context.Context
 		cloneErr        error
 		wantMsgContains []string
+		wantMsgExcludes []string
 	}{
 		{
-			name: "context timeout",
+			name:            "context.DeadlineExceeded in clone error",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        context.DeadlineExceeded,
+			wantMsgContains: []string{"timed out", "kubechecks replan"},
+		},
+		{
+			name:            "context.Canceled in clone error",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        context.Canceled,
+			wantMsgContains: []string{"timed out", "kubechecks replan"},
+		},
+		{
+			// HTTP error in cloneErr takes priority even when ctx is also cancelled
+			name: "HTTP 503 with cancelled ctx — HTTP wins",
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return ctx
 			},
-			cloneErr:        fmt.Errorf("deadline exceeded"),
+			cloneErr:        &HTTPError{StatusCode: http.StatusServiceUnavailable},
+			wantMsgContains: []string{"503", "kubechecks replan"},
+			wantMsgExcludes: []string{"timed out"},
+		},
+		{
+			// ctx cancelled, no typed error — falls through to ctx.Err() branch
+			name: "cancelled ctx with generic error — ctx fallback",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			cloneErr:        fmt.Errorf("some generic failure"),
 			wantMsgContains: []string{"timed out", "kubechecks replan"},
 		},
 		{
@@ -59,10 +85,19 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			wantMsgContains: []string{"503", "Service Unavailable", "kubechecks replan"},
 		},
 		{
-			name:            "HTTP 403 other 4xx",
+			// Auth errors should not suggest retrying — retrying won't fix bad credentials
+			name:            "HTTP 401 unauthorized — no retry suggestion",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &HTTPError{StatusCode: http.StatusUnauthorized},
+			wantMsgContains: []string{"401", "credentials"},
+			wantMsgExcludes: []string{"kubechecks replan"},
+		},
+		{
+			name:            "HTTP 403 forbidden — no retry suggestion",
 			ctx:             func() context.Context { return context.Background() },
 			cloneErr:        &HTTPError{StatusCode: http.StatusForbidden},
-			wantMsgContains: []string{"403", "Forbidden", "kubechecks replan"},
+			wantMsgContains: []string{"403", "credentials"},
+			wantMsgExcludes: []string{"kubechecks replan"},
 		},
 		{
 			name:            "wrapped HTTP 502",
@@ -84,18 +119,20 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			mockClient.On("PostMessage", mock.Anything, pr, mock.AnythingOfType("string")).
 				Return(nil, nil)
 
-			m := newTestManager(t, mockClient)
+			m := newTestManager(mockClient)
 			ctx := tt.ctx()
 
 			err := m.PostArchiveErrorMessage(ctx, pr, tt.cloneErr)
 			assert.NoError(t, err)
 
-			// Capture the posted message and assert it contains expected substrings
 			calls := mockClient.Calls
 			assert.Len(t, calls, 1, "expected exactly one PostMessage call")
 			postedMsg := calls[0].Arguments.String(2)
 			for _, want := range tt.wantMsgContains {
 				assert.Contains(t, postedMsg, want)
+			}
+			for _, excluded := range tt.wantMsgExcludes {
+				assert.NotContains(t, postedMsg, excluded)
 			}
 		})
 	}
@@ -105,7 +142,7 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 		mockClient.On("PostMessage", mock.Anything, pr, mock.AnythingOfType("string")).
 			Return(nil, fmt.Errorf("vcs unavailable"))
 
-		m := newTestManager(t, mockClient)
+		m := newTestManager(mockClient)
 		err := m.PostArchiveErrorMessage(context.Background(), pr, fmt.Errorf("network error"))
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "vcs unavailable")

--- a/pkg/archive/manager_test.go
+++ b/pkg/archive/manager_test.go
@@ -104,18 +104,27 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			wantMsgContains: []string{"503", "Service Unavailable", "kubechecks replan"},
 		},
 		{
-			// Auth errors must not suggest retrying — the credentials need fixing, not a retry
-			name:            "HTTP 401 unauthorized — no retry suggestion",
+			// 401 = bad/missing token — say "authentication", not "authorization"
+			name:            "HTTP 401 unauthorized — authentication message, no retry",
 			ctx:             func() context.Context { return context.Background() },
 			cloneErr:        &HTTPError{StatusCode: http.StatusUnauthorized},
-			wantMsgContains: []string{"401", "credentials"},
-			wantMsgExcludes: []string{"kubechecks replan"},
+			wantMsgContains: []string{"401", "Authentication", "token"},
+			wantMsgExcludes: []string{"kubechecks replan", "Authorization", "permissions"},
 		},
 		{
-			name:            "HTTP 403 forbidden — no retry suggestion",
+			// 403 = insufficient scope — say "authorization"/"permissions", not "authentication"
+			name:            "HTTP 403 forbidden — authorization message, no retry",
 			ctx:             func() context.Context { return context.Background() },
 			cloneErr:        &HTTPError{StatusCode: http.StatusForbidden},
-			wantMsgContains: []string{"403", "credentials"},
+			wantMsgContains: []string{"403", "permissions"},
+			wantMsgExcludes: []string{"kubechecks replan", "Authentication"},
+		},
+		{
+			// URL parse failure is a bug — no replan suggestion
+			name:            "urlParseError — no retry suggestion",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &urlParseError{err: fmt.Errorf("unrecognized archive URL format: https://example.com/unknown")},
+			wantMsgContains: []string{"parse", "kubechecks logs"},
 			wantMsgExcludes: []string{"kubechecks replan"},
 		},
 		{

--- a/pkg/archive/manager_test.go
+++ b/pkg/archive/manager_test.go
@@ -65,7 +65,7 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			name: "cancelled ctx (deadline) with generic error — timeout fallback",
 			ctx: func() context.Context {
 				ctx, cancel := context.WithTimeout(context.Background(), 0)
-				defer cancel()
+				cancel()
 				return ctx
 			},
 			cloneErr:                fmt.Errorf("some generic failure"),

--- a/pkg/archive/manager_test.go
+++ b/pkg/archive/manager_test.go
@@ -128,6 +128,14 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			wantMsgExcludes: []string{"kubechecks replan"},
 		},
 		{
+			// 400/422/405/410 are permanent — no replan suggestion
+			name:            "HTTP 422 unprocessable — permanent 4xx, no retry",
+			ctx:             func() context.Context { return context.Background() },
+			cloneErr:        &HTTPError{StatusCode: http.StatusUnprocessableEntity},
+			wantMsgContains: []string{"422", "permanent error", "kubechecks logs"},
+			wantMsgExcludes: []string{"kubechecks replan"},
+		},
+		{
 			name:            "wrapped HTTP 502",
 			ctx:             func() context.Context { return context.Background() },
 			cloneErr:        errors.Wrap(&HTTPError{StatusCode: http.StatusBadGateway}, "failed to download"),

--- a/pkg/archive/manager_test.go
+++ b/pkg/archive/manager_test.go
@@ -25,11 +25,12 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 	pr := vcs.PullRequest{FullName: "org/repo", CheckID: 42, BaseRef: "main"}
 
 	tests := []struct {
-		name            string
-		ctx             func() context.Context
-		cloneErr        error
-		wantMsgContains []string
-		wantMsgExcludes []string
+		name                    string
+		ctx                     func() context.Context
+		cloneErr                error
+		wantMsgContains         []string
+		wantMsgExcludes         []string
+		wantNonCancelledPostCtx bool // assert PostMessage receives a non-cancelled context
 	}{
 		{
 			name:            "context.DeadlineExceeded in clone error",
@@ -38,33 +39,51 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			wantMsgContains: []string{"timed out", "kubechecks replan"},
 		},
 		{
+			// Canceled ≠ timeout — should say "interrupted", not "timed out"
 			name:            "context.Canceled in clone error",
 			ctx:             func() context.Context { return context.Background() },
 			cloneErr:        context.Canceled,
-			wantMsgContains: []string{"timed out", "kubechecks replan"},
-		},
-		{
-			// HTTP error in cloneErr takes priority even when ctx is also cancelled
-			name: "HTTP 503 with cancelled ctx — HTTP wins",
-			ctx: func() context.Context {
-				ctx, cancel := context.WithCancel(context.Background())
-				cancel()
-				return ctx
-			},
-			cloneErr:        &HTTPError{StatusCode: http.StatusServiceUnavailable},
-			wantMsgContains: []string{"503", "kubechecks replan"},
+			wantMsgContains: []string{"interrupted", "kubechecks replan"},
 			wantMsgExcludes: []string{"timed out"},
 		},
 		{
-			// ctx cancelled, no typed error — falls through to ctx.Err() branch
-			name: "cancelled ctx with generic error — ctx fallback",
+			// HTTP error in cloneErr takes priority even when ctx is also cancelled;
+			// PostMessage must receive a fresh (non-cancelled) context.
+			name: "HTTP 503 with cancelled ctx — HTTP wins, fresh postCtx",
 			ctx: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return ctx
 			},
-			cloneErr:        fmt.Errorf("some generic failure"),
-			wantMsgContains: []string{"timed out", "kubechecks replan"},
+			cloneErr:                &HTTPError{StatusCode: http.StatusServiceUnavailable},
+			wantMsgContains:         []string{"503", "kubechecks replan"},
+			wantMsgExcludes:         []string{"timed out", "interrupted"},
+			wantNonCancelledPostCtx: true,
+		},
+		{
+			// ctx cancelled with DeadlineExceeded, no typed error — ctx.Err() fallback (timeout)
+			name: "cancelled ctx (deadline) with generic error — timeout fallback",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 0)
+				defer cancel()
+				return ctx
+			},
+			cloneErr:                fmt.Errorf("some generic failure"),
+			wantMsgContains:         []string{"timed out", "kubechecks replan"},
+			wantNonCancelledPostCtx: true,
+		},
+		{
+			// ctx cancelled (not deadline), no typed error — ctx.Err() fallback (interrupted)
+			name: "cancelled ctx (cancel) with generic error — interrupted fallback",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			cloneErr:                fmt.Errorf("some generic failure"),
+			wantMsgContains:         []string{"interrupted", "kubechecks replan"},
+			wantMsgExcludes:         []string{"timed out"},
+			wantNonCancelledPostCtx: true,
 		},
 		{
 			name:            "HTTP 404 not found",
@@ -85,7 +104,7 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			wantMsgContains: []string{"503", "Service Unavailable", "kubechecks replan"},
 		},
 		{
-			// Auth errors should not suggest retrying — retrying won't fix bad credentials
+			// Auth errors must not suggest retrying — the credentials need fixing, not a retry
 			name:            "HTTP 401 unauthorized — no retry suggestion",
 			ctx:             func() context.Context { return context.Background() },
 			cloneErr:        &HTTPError{StatusCode: http.StatusUnauthorized},
@@ -116,7 +135,14 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := vcsmocks.NewMockClient(t)
+
+			// postCtxErr is captured inside Run so we observe Err() before
+			// the deferred cancel() in PostArchiveErrorMessage fires on return.
+			var postCtxErr error
 			mockClient.On("PostMessage", mock.Anything, pr, mock.AnythingOfType("string")).
+				Run(func(args mock.Arguments) {
+					postCtxErr = args.Get(0).(context.Context).Err()
+				}).
 				Return(nil, nil)
 
 			m := newTestManager(mockClient)
@@ -133,6 +159,9 @@ func TestPostArchiveErrorMessage(t *testing.T) {
 			}
 			for _, excluded := range tt.wantMsgExcludes {
 				assert.NotContains(t, postedMsg, excluded)
+			}
+			if tt.wantNonCancelledPostCtx {
+				assert.NoError(t, postCtxErr, "PostMessage should receive a non-cancelled context when original ctx is done")
 			}
 		})
 	}

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -300,6 +300,10 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 	// Download and extract archive (contains merged state)
 	repo, err = ce.ctr.ArchiveManager.Clone(ctx, ce.pullRequest.CloneURL, ce.pullRequest.BaseRef, ce.pullRequest)
 	if err != nil {
+		// Note: PostArchiveErrorMessage is also called for pre-download failures
+		// (e.g. DownloadArchive timeout, unrecognized URL format). Those fall through
+		// to the generic "transient error" message, which is acceptable for the timeout
+		// case (user can retry) but misleading for permanent URL parse failures (rare).
 		if postErr := ce.ctr.ArchiveManager.PostArchiveErrorMessage(ctx, ce.pullRequest, err); postErr != nil {
 			ce.logger.Error().Caller().Err(postErr).Msg("failed to post archive error message")
 		}

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -300,6 +300,9 @@ func (ce *CheckEvent) Process(ctx context.Context) error {
 	// Download and extract archive (contains merged state)
 	repo, err = ce.ctr.ArchiveManager.Clone(ctx, ce.pullRequest.CloneURL, ce.pullRequest.BaseRef, ce.pullRequest)
 	if err != nil {
+		if postErr := ce.ctr.ArchiveManager.PostArchiveErrorMessage(ctx, ce.pullRequest, err); postErr != nil {
+			ce.logger.Error().Caller().Err(postErr).Msg("failed to post archive error message")
+		}
 		return errors.Wrap(err, "failed to download archive")
 	}
 


### PR DESCRIPTION
# feat(archive): retry download on transient failures, surface typed errors to PR

## Problem

Archive mode downloads the merged repository state from GitHub/GitLab as a zip and extracts it locally. About 1 in 10 times, `Cache.GetOrDownload` would fail with a transient error — a brief network hiccup, CDN propagation lag after GitHub computes a merge commit, or a momentary 5xx from the VCS — and the check would hard-fail with no retry and no useful message to the PR author.

Two distinct issues:

1. **No retry** — a single transient HTTP or network failure would immediately terminate the check.
2. **No actionable PR feedback** — when the download did fail, the PR received no comment at all, leaving the author with no idea what happened or how to proceed.

## What changed

### 1. Typed errors (`pkg/archive/download.go`, `pkg/archive/manager.go`)

Previously, non-200 HTTP responses were returned as a plain `fmt.Errorf` string. Any code wanting to branch on the status code had to parse that string — fragile and easy to break silently.

Three typed errors are introduced:

**`HTTPError`** — carries the HTTP status code so retry and message decisions use integer comparisons via `errors.As`, not string parsing. The `.Error()` string is identical to before, so logs are unchanged.

```go
type HTTPError struct {
    StatusCode int
    URL        string
    Body       string // raw response snippet, kept out of PR comments (may contain sensitive server data)
}
```

**`extractError`** — wraps failures from the local zip extraction step (path traversal, zip corruption, disk full, permission errors). These are permanent — retrying the download won't change the outcome, so `isRetriableDownloadError` short-circuits immediately for this type.

**`urlParseError`** — wraps failures from `extractSHAFromArchiveURL`. An unrecognized archive URL format is a configuration/compatibility bug, not something the user can fix by retrying, so `PostArchiveErrorMessage` posts a specific "check the logs" message with no replan instruction.

### 2. `isRetriableDownloadError` (`pkg/archive/download.go`)

A package-level function classifies errors as retriable or permanent:

| Error type | Decision | Reason |
|---|---|---|
| `ctx.Err() != nil` | Not retriable | Context cancelled/timed out — retrying is pointless |
| `*extractError` | Not retriable | Local extraction failure — same archive yields same result |
| `*HTTPError` 404 | Retriable | Archive CDN may not have propagated the merge commit yet |
| `*HTTPError` 429 | Retriable | Rate limited — back off and try again |
| `*HTTPError` 5xx | Retriable | Transient server error |
| `*HTTPError` other 4xx | Not retriable | Permanent client/auth error — retrying won't help |
| Non-HTTP error | Retriable | Network-level failure (connection refused, EOF, timeout) |

`errors.As` traverses the full wrapped error chain, so this works correctly even when errors are buried under multiple `errors.Wrap` layers.

### 3. Retry loop in `Cache.GetOrDownload` (`pkg/archive/cache.go`)

The download is retried up to **3 attempts** with **10s → 20s** exponential backoff. Critically, the **retry loop runs outside the `singleflight` call** — each attempt is its own `singleflight.Do`:

```
attempt 1: singleflight.Do → fail (transient) → key released
           backoff 10s (outside singleflight — callers with expired contexts exit here)
attempt 2: singleflight.Do → fail (transient) → key released
           backoff 20s
attempt 3: singleflight.Do → success or permanent failure
```

This design means:
- The singleflight key is held only for the duration of a single download attempt, not the full retry window
- Concurrent callers for the same SHA are still coalesced per attempt — only one download happens at a time
- A caller whose context expires during backoff exits cleanly via `ctx.Done()` rather than being stuck inside singleflight for up to 30s
- Callers arriving during backoff can trigger the next attempt immediately without waiting

A fast-path cache check runs before the retry loop so cache hits never touch singleflight at all. Inside each `singleflight.Do`, the cache is re-checked first in case another caller populated it during the backoff window.

Partial `targetDir` cleanup happens inside the lambda at the start of each attempt (`os.RemoveAll` is a no-op when the directory doesn't exist yet), ensuring any corrupt state from a previous attempt by any caller is cleared before the next download begins.

When `shared == true` (the singleflight coalesced concurrent callers), a log line is emitted with the wait duration — useful for diagnosing latency during VCS outages.

Non-retriable errors short-circuit the loop immediately.

### 4. `PostArchiveErrorMessage` (`pkg/archive/manager.go`)

When all retries are exhausted and `Clone` returns an error, `check.go` calls `PostArchiveErrorMessage` to post a specific, actionable comment. The error is classified by inspecting the error chain via `errors.As` and `errors.Is`:

| Failure | Comment | Replan? |
|---|---|---|
| `context.DeadlineExceeded` in error | "Kubechecks timed out — VCS may still be computing merge result" | Yes |
| `context.Canceled` in error | "Download was interrupted — usually a shutdown/restart" | Yes |
| HTTP 404 | "Archive not found — VCS may still be preparing it" | Yes |
| HTTP 429 | "Rate limited" | Yes |
| HTTP 5xx | "VCS server error (HTTP {code} {text})" | Yes |
| HTTP 401 | "Authentication failed — check VCS token" | No |
| HTTP 403 | "Access denied — check token permissions" | No |
| Other 4xx (400, 405, 422…) | "Permanent error — check kubechecks logs" | No |
| `*urlParseError` | "Could not parse archive URL — configuration issue, check logs" | No |
| `ctx.Err() == DeadlineExceeded` (fallback) | "Timed out" | Yes |
| `ctx.Err() != nil` (fallback) | "Interrupted" | Yes |
| Generic/network | "Transient error" | Yes |

Two important edge cases:
- **401 vs 403**: HTTP 401 means authentication failure (missing/invalid token); 403 means authorization failure (token valid but insufficient scope). These produce different messages to help operators diagnose credential issues accurately.
- **Cancelled context**: if the original context is already cancelled when `PostArchiveErrorMessage` runs, the `PostMessage` call uses `context.WithTimeout(context.Background(), 30s)` instead — so the comment is still delivered but the goroutine is bounded and cannot hang indefinitely.
- **`context.DeadlineExceeded` vs `context.Canceled`**: the error itself is checked first via `errors.Is`; `ctx.Err()` is only a fallback for cases where the context happened to cancel for an unrelated reason after `Clone` returned.

The "timed out" and "interrupted" message strings are defined once as variables and reused in both the `cloneErr` branch and the `ctx.Err()` fallback, eliminating drift if wording is ever updated.

### 5. `check.go` wiring (`pkg/events/check.go`)

Three lines added after `Clone` fails to call `PostArchiveErrorMessage`. The error from `Clone` still returns and propagates normally — the comment is best-effort and does not affect the error path.

Note: `PostArchiveErrorMessage` is also called for pre-download failures from `DownloadArchive` (e.g. VCS timeout) and `extractSHAFromArchiveURL`. The former is legitimately retriable (user can replan); the latter is now handled via `urlParseError` and posts a no-replan message.

## Tests

**`pkg/archive/download_test.go` — `TestIsRetriableDownloadError` (18 cases)**

Covers the full decision matrix: nil error, cancelled context, each retriable HTTP code (404, 429, 500, 502, 503), each permanent HTTP code (400, 401, 403, 422), errors wrapped with `errors.Wrap` to verify `errors.As` chain traversal, raw network errors, `extractError` (direct and wrapped).

**`pkg/archive/manager_test.go` — `TestPostArchiveErrorMessage` (15 cases)**

Uses `MockClient` with a `Run` callback to capture the context and message passed to `PostMessage`. Asserts:
- Correct substrings present/absent in posted message per error branch
- `PostMessage` receives a non-cancelled context when the original ctx was done (verifying the `context.WithTimeout` fallback) — captured inside `mock.Run` before the deferred `cancel()` fires
- `PostMessage` failures propagate correctly

Assertions use `Contains`/`NotContains` rather than exact string matching so message copy can be adjusted without touching tests.

## What was deliberately not changed

- **Conflict detection** — `DownloadArchive` in both GitHub and GitLab clients already implements retry-with-backoff for the "merge commit not yet computed" phase and returns a terminal error when the PR is not mergeable. This PR does not touch that logic.
- **`ValidatePullRequest`** — the pre-check that posts `PostConflictMessage` is unchanged.
- **`Downloader` interface** — the downloader is not yet injectable, so retry behaviour cannot be unit-tested at the HTTP level without an `httptest.Server`. Tracked as future work.
- **Duplicate comments on concurrent failures** — if two concurrent `CheckEvent`s for the same SHA both fail (e.g. a replan fired while a check was already running), both independently call `PostArchiveErrorMessage` and the PR receives two identical comments. De-duplicating this would require per-SHA "already posted" state and adds complexity disproportionate to the impact. Printing twice is acceptable.
