### PR TITLE
fix(diff): pass AppNamespace to ManagedResources query

### DIFF
--- a/pkg/checks/diff/diff.go
+++ b/pkg/checks/diff/diff.go
@@ -242,6 +242,7 @@ func getResources(ctx context.Context, request checks.Request) ([]*argoappv1.Res
 
 	resources, err := appClient.ManagedResources(ctx, &application.ResourcesQuery{
 		ApplicationName: &request.App.Name,
+		AppNamespace:    &request.App.Namespace,
 	})
 	if err != nil {
 		if isAppMissingErr(err) {


### PR DESCRIPTION
## Summary

For ArgoCD instances configured for [multi-namespace Applications](https://argo-cd.readthedocs.io/en/stable/operator-manual/app-any-namespace/), the diff check's `ManagedResources` gRPC call omits `AppNamespace`, so ArgoCD looks for the `Application` object in argocd-server's own namespace and returns `PermissionDenied` (the convention to avoid leaking existence). The error is then swallowed by `isAppMissingErr` in `pkg/checks/diff/diff.go`, returning an empty resource list. The downstream effect is that every diff reports `N added, 0 modified, 0 removed` regardless of the actual change.

## Symptom

For any ArgoCD `Application` whose `metadata.namespace` is **not** the argocd-server's own namespace:

- The PR comment shows the rendered manifests under the diff section as if they were all being created.
- The added/modified/removed summary always reads `N added, 0 modified, 0 removed`.
- Diff resource headers have empty namespaces (`/Deployment /myapp` rather than `/Deployment my-ns/myapp`), because `DeduplicateTargetObjects` can't backfill the namespace when `liveObjs` is empty.

## Reproduction

The argocd CLI uses the same gRPC API:

```
# kubechecks-style call (no AppNamespace) — fails
argocd app resources <app-name>

# Same app, qualified with namespace — works
argocd app resources <app-namespace>/<app-name>
```

argocd-server logs from a multi-namespace setup:

```
ManagedResources ... applicationName:"<app-name>"        # no appNamespace field
"application does not exist" application=<app-name> namespace=<argocd-ns> user=kubechecks
grpc.code=PermissionDenied
```

confirming that PermissionDenied is returned because ArgoCD looked for the Application in its own namespace and didn't find it — RBAC isn't the gate, the missing field is.

## Fix

Pass `AppNamespace: &request.App.Namespace` alongside `ApplicationName`. Other ArgoCD gRPC calls already made by kubechecks include `appNamespace` (`Get`, `ResourceTree` — visible in the same argocd-server logs from the kubechecks pod), so this aligns `ManagedResources` with the rest of the kubechecks -> ArgoCD API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)