### PR TITLE
fix the clone so that it also uses github app auth, when appropriate

### DIFF
--- a/mocks/vcs/mocks/mock_MockClient.go
+++ b/mocks/vcs/mocks/mock_MockClient.go
@@ -389,6 +389,72 @@ func (_c *MockClient_GetAuthHeaders_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
+// GitCredentials provides a mock function for the type MockClient
+func (_mock *MockClient) GitCredentials(ctx context.Context) (string, string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GitCredentials")
+	}
+
+	var r0 string
+	var r1 string
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) string); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = returnFunc(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockClient_GitCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GitCredentials'
+type MockClient_GitCredentials_Call struct {
+	*mock.Call
+}
+
+// GitCredentials is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockClient_Expecter) GitCredentials(ctx interface{}) *MockClient_GitCredentials_Call {
+	return &MockClient_GitCredentials_Call{Call: _e.mock.On("GitCredentials", ctx)}
+}
+
+func (_c *MockClient_GitCredentials_Call) Run(run func(ctx context.Context)) *MockClient_GitCredentials_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_GitCredentials_Call) Return(s string, s1 string, err error) *MockClient_GitCredentials_Call {
+	_c.Call.Return(s, s1, err)
+	return _c
+}
+
+func (_c *MockClient_GitCredentials_Call) RunAndReturn(run func(ctx context.Context) (string, string, error)) *MockClient_GitCredentials_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetHookByUrl provides a mock function for the type MockClient
 func (_mock *MockClient) GetHookByUrl(ctx context.Context, repoName string, webhookUrl string) (*vcs.WebHookConfig, error) {
 	ret := _mock.Called(ctx, repoName, webhookUrl)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -13,6 +14,13 @@ import (
 
 	"github.com/zapier/kubechecks/pkg"
 )
+
+// GitCredsFunc returns HTTP basic-auth credentials for git-over-HTTPS operations
+// (cloning policy and schema repositories). The returned password may be short-lived —
+// for example a GitHub App installation token that is refreshed on demand — so callers
+// must invoke this per operation and must not cache the result. An empty password means
+// anonymous access.
+type GitCredsFunc func(ctx context.Context) (username, password string, err error)
 
 // set default values in /cmd/root.go's init function
 
@@ -49,6 +57,12 @@ type ServerConfig struct {
 	GithubPrivateKey     string `mapstructure:"github-private-key"`
 	GithubAppID          int64  `mapstructure:"github-app-id"`
 	GithubInstallationID int64  `mapstructure:"github-installation-id"`
+
+	// GitCreds supplies credentials for git-over-HTTPS operations (cloning policy and
+	// schema repositories). It is populated at startup from the VCS client rather than
+	// from configuration — a static token for PAT auth, or a refreshing installation
+	// token for GitHub App auth. When nil, git operations fall back to VcsToken.
+	GitCreds GitCredsFunc `mapstructure:"-" json:"-"`
 
 	// webhooks
 	EnsureWebhooks bool   `mapstructure:"ensure-webhooks"`

--- a/pkg/container/main.go
+++ b/pkg/container/main.go
@@ -47,8 +47,7 @@ func New(ctx context.Context, cfg config.ServerConfig) (Container, error) {
 	var err error
 
 	var ctr = Container{
-		Config:      cfg,
-		RepoManager: git.NewRepoManager(cfg),
+		Config: cfg,
 	}
 
 	// create vcs client
@@ -63,6 +62,13 @@ func New(ctx context.Context, cfg config.ServerConfig) (Container, error) {
 	if err != nil {
 		return ctr, errors.Wrap(err, "failed to create vcs client")
 	}
+
+	// Route git-over-HTTPS credentials (used to clone policy and schema repositories)
+	// through the VCS client so GitHub App installation tokens work for clones, not just
+	// the REST API. The repo manager is created afterwards so it picks this up.
+	cfg.GitCreds = ctr.VcsClient.GitCredentials
+	ctr.Config = cfg
+	ctr.RepoManager = git.NewRepoManager(cfg)
 
 	// Initialize archive manager for VCS archive downloads
 	log.Info().Msg("initializing archive manager for VCS archive downloads")

--- a/pkg/events/check.go
+++ b/pkg/events/check.go
@@ -251,7 +251,7 @@ func (ce *CheckEvent) getRepo(ctx context.Context, cloneURL, branchName string) 
 
 	// if we cloned 'HEAD', figure out its original branch and store a copy of the repo there
 	if branchName == "HEAD" {
-		remoteHeadBranchName, err := repo.GetRemoteHead()
+		remoteHeadBranchName, err := repo.GetRemoteHead(ctx)
 		if err != nil {
 			return repo, errors.Wrap(err, "failed to determine remote head")
 		}
@@ -264,7 +264,7 @@ func (ce *CheckEvent) getRepo(ctx context.Context, cloneURL, branchName string) 
 	// and if it's the one we just cloned, store a copy of it as 'HEAD' for usage later
 	headKey := generateRepoKey(parsed, "HEAD")
 	if _, ok := ce.clonedRepos[headKey]; !ok {
-		remoteHeadBranchName, err := repo.GetRemoteHead()
+		remoteHeadBranchName, err := repo.GetRemoteHead(ctx)
 		if err != nil {
 			return repo, errors.Wrap(err, "failed to determine remote head")
 		}

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -51,12 +51,28 @@ func New(cfg config.ServerConfig, cloneUrl, branchName string) *Repo {
 	}
 }
 
-// getAuth returns authentication options for go-git operations
-// Returns nil for anonymous/public access when no token is configured
-func (r *Repo) getAuth() *gogithttp.BasicAuth {
+// getAuth returns authentication options for go-git operations.
+// Returns nil for anonymous/public access when no credentials are configured.
+//
+// When a credential provider is configured (config.GitCreds) it is used, which allows
+// GitHub App installation tokens to authenticate clones — the App transport only backs
+// the REST API client, so git-over-HTTPS needs credentials resolved here. It falls back
+// to the static VcsToken when no provider is set.
+func (r *Repo) getAuth(ctx context.Context) (*gogithttp.BasicAuth, error) {
+	if r.Config.GitCreds != nil {
+		username, password, err := r.Config.GitCreds(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get git credentials")
+		}
+		if password == "" {
+			return nil, nil
+		}
+		return &gogithttp.BasicAuth{Username: username, Password: password}, nil
+	}
+
 	// If no token configured, use anonymous access (for public repos)
 	if r.Config.VcsToken == "" {
-		return nil
+		return nil, nil
 	}
 
 	// Extract username from clone URL if present, otherwise use default
@@ -68,7 +84,7 @@ func (r *Repo) getAuth() *gogithttp.BasicAuth {
 	return &gogithttp.BasicAuth{
 		Username: username,
 		Password: r.Config.VcsToken,
-	}
+	}, nil
 }
 
 func (r *Repo) Clone(ctx context.Context) error {
@@ -90,10 +106,15 @@ func (r *Repo) Clone(ctx context.Context) error {
 	_, span := tracer.Start(ctx, "CloneRepo")
 	defer span.End()
 
+	auth, err := r.getAuth(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get git credentials")
+	}
+
 	// Prepare clone options
 	cloneOpts := &gogit.CloneOptions{
 		URL:  r.CloneURL,
-		Auth: r.getAuth(),
+		Auth: auth,
 	}
 
 	// If branch is specified and not HEAD, checkout that branch after clone
@@ -112,7 +133,7 @@ func (r *Repo) Clone(ctx context.Context) error {
 
 	// Set up refs/remotes/origin/HEAD symbolic reference
 	// This is needed by GetRemoteHead() and mirrors what git binary does automatically
-	if err := r.setupRemoteHead(repo); err != nil {
+	if err := r.setupRemoteHead(ctx, repo); err != nil {
 		log.Warn().Err(err).Msg("failed to set up refs/remotes/origin/HEAD, continuing anyway")
 		// Don't fail the clone operation, GetRemoteHead() has fallback logic
 	}
@@ -129,15 +150,20 @@ func (r *Repo) Clone(ctx context.Context) error {
 
 // setupRemoteHead creates the refs/remotes/origin/HEAD symbolic reference
 // that points to the default branch. This mirrors what git binary does automatically.
-func (r *Repo) setupRemoteHead(repo *gogit.Repository) error {
+func (r *Repo) setupRemoteHead(ctx context.Context, repo *gogit.Repository) error {
 	// Query the remote to find the default branch
 	remote, err := repo.Remote("origin")
 	if err != nil {
 		return errors.Wrap(err, "failed to get origin remote")
 	}
 
+	auth, err := r.getAuth(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get git credentials")
+	}
+
 	refs, err := remote.List(&gogit.ListOptions{
-		Auth: r.getAuth(),
+		Auth: auth,
 	})
 	if err != nil {
 		return errors.Wrap(err, "failed to list remote refs")
@@ -184,7 +210,7 @@ func printFile(s string, d fs.DirEntry, err error) error {
 	return nil
 }
 
-func (r *Repo) GetRemoteHead() (string, error) {
+func (r *Repo) GetRemoteHead(ctx context.Context) (string, error) {
 	repo, err := gogit.PlainOpen(r.Directory)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to open repository")
@@ -206,9 +232,14 @@ func (r *Repo) GetRemoteHead() (string, error) {
 		return "", errors.Wrap(err, "failed to get remote 'origin'")
 	}
 
+	auth, err := r.getAuth(ctx)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get git credentials")
+	}
+
 	// List remote refs to find HEAD
 	refs, err := remote.List(&gogit.ListOptions{
-		Auth: r.getAuth(),
+		Auth: auth,
 	})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to list remote refs")
@@ -295,10 +326,16 @@ func (r *Repo) Update(ctx context.Context) error {
 		return errors.Wrap(err, "failed to open repository")
 	}
 
+	auth, err := r.getAuth(ctx)
+	if err != nil {
+		repoFetchFailed.Inc()
+		return errors.Wrap(err, "failed to get git credentials")
+	}
+
 	// Fetch latest changes from remote
 	fetchOpts := &gogit.FetchOptions{
 		RemoteName: "origin",
-		Auth:       r.getAuth(),
+		Auth:       auth,
 	}
 
 	// If branch is specified, fetch only that branch

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -62,7 +62,9 @@ func (r *Repo) getAuth(ctx context.Context) (*gogithttp.BasicAuth, error) {
 	if r.Config.GitCreds != nil {
 		username, password, err := r.Config.GitCreds(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to get git credentials")
+			// Return the provider error unwrapped; every caller wraps it with
+			// "failed to get git credentials", so wrapping here too would duplicate that context.
+			return nil, err
 		}
 		if password == "" {
 			return nil, nil

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -21,7 +21,7 @@ func TestRepoGetRemoteHead(t *testing.T) {
 
 	t.Cleanup(repo.Wipe)
 
-	branch, err := repo.GetRemoteHead()
+	branch, err := repo.GetRemoteHead(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, "main", branch)
 	currentBranch, err := repo.GetCurrentBranch()

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -4,11 +4,77 @@ import (
 	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/zapier/kubechecks/pkg/config"
 )
+
+func TestRepoGetAuth(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("credential provider success", func(t *testing.T) {
+		cfg := config.ServerConfig{
+			GitCreds: func(context.Context) (string, string, error) {
+				return "x-access-token", "ghs_installation_token", nil
+			},
+		}
+		repo := New(cfg, "https://github.com/zapier/kubechecks.git", "")
+
+		auth, err := repo.getAuth(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, auth)
+		assert.Equal(t, "x-access-token", auth.Username)
+		assert.Equal(t, "ghs_installation_token", auth.Password)
+	})
+
+	t.Run("credential provider empty password means anonymous", func(t *testing.T) {
+		cfg := config.ServerConfig{
+			GitCreds: func(context.Context) (string, string, error) {
+				return "x-access-token", "", nil
+			},
+		}
+		repo := New(cfg, "https://github.com/zapier/kubechecks.git", "")
+
+		auth, err := repo.getAuth(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, auth)
+	})
+
+	t.Run("credential provider error propagates without duplicate wrapping", func(t *testing.T) {
+		cfg := config.ServerConfig{
+			GitCreds: func(context.Context) (string, string, error) {
+				return "", "", errors.New("token fetch failed")
+			},
+		}
+		repo := New(cfg, "https://github.com/zapier/kubechecks.git", "")
+
+		auth, err := repo.getAuth(ctx)
+		require.Error(t, err)
+		assert.Nil(t, auth)
+		assert.Equal(t, "token fetch failed", err.Error())
+	})
+
+	t.Run("falls back to VcsToken when no provider configured", func(t *testing.T) {
+		cfg := config.ServerConfig{VcsToken: "ghp_static_pat"}
+		repo := New(cfg, "https://github.com/zapier/kubechecks.git", "")
+
+		auth, err := repo.getAuth(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, auth)
+		assert.Equal(t, "git", auth.Username)
+		assert.Equal(t, "ghp_static_pat", auth.Password)
+	})
+
+	t.Run("anonymous when neither provider nor VcsToken configured", func(t *testing.T) {
+		repo := New(config.ServerConfig{}, "https://github.com/zapier/kubechecks.git", "")
+
+		auth, err := repo.getAuth(ctx)
+		require.NoError(t, err)
+		assert.Nil(t, auth)
+	})
+}
 
 func TestRepoGetRemoteHead(t *testing.T) {
 	cfg := config.ServerConfig{}

--- a/pkg/vcs/github_client/client.go
+++ b/pkg/vcs/github_client/client.go
@@ -165,18 +165,30 @@ func (c *Client) CloneUsername() string {
 	}
 }
 
+// gitToken returns the secret used to authenticate git-over-HTTPS operations and archive
+// downloads. For GitHub App auth it fetches a fresh installation token from the underlying
+// transport (ghinstallation caches and refreshes it); for PAT auth it returns the static
+// VcsToken. These paths bypass the SDK's authenticated transport, so the token must be
+// resolved explicitly here.
+func (c *Client) gitToken(ctx context.Context) (string, error) {
+	if c.appTokenSource != nil {
+		t, err := c.appTokenSource.Token(ctx)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to fetch GitHub App installation token")
+		}
+		return t, nil
+	}
+	return c.cfg.VcsToken, nil
+}
+
 // GetAuthHeaders returns HTTP headers needed for authenticated archive downloads.
 // For GitHub App auth it fetches a fresh installation token from the underlying transport;
 // for PAT auth it returns the configured token. GitHub accepts both `Bearer <token>` and
 // `token <token>`; Bearer is the modern form.
 func (c *Client) GetAuthHeaders(ctx context.Context) (map[string]string, error) {
-	token := c.cfg.VcsToken
-	if c.appTokenSource != nil {
-		t, err := c.appTokenSource.Token(ctx)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to fetch GitHub App installation token")
-		}
-		token = t
+	token, err := c.gitToken(ctx)
+	if err != nil {
+		return nil, err
 	}
 	if token == "" {
 		return nil, errors.New("no GitHub credentials configured for archive download")
@@ -184,6 +196,18 @@ func (c *Client) GetAuthHeaders(ctx context.Context) (map[string]string, error) 
 	return map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", token),
 	}, nil
+}
+
+// GitCredentials returns HTTP basic-auth credentials for git-over-HTTPS operations
+// (cloning policy and schema repositories). In GitHub App mode the username must be
+// "x-access-token" and the password is a short-lived installation token, so it is
+// resolved per call.
+func (c *Client) GitCredentials(ctx context.Context) (string, string, error) {
+	token, err := c.gitToken(ctx)
+	if err != nil {
+		return "", "", err
+	}
+	return c.CloneUsername(), token, nil
 }
 
 var nilPr vcs.PullRequest

--- a/pkg/vcs/github_client/client_test.go
+++ b/pkg/vcs/github_client/client_test.go
@@ -556,6 +556,47 @@ func TestClient_GetAuthHeaders_GitHubApp_TokenFetchError(t *testing.T) {
 	assert.Contains(t, err.Error(), "installation token")
 }
 
+func TestClient_GitCredentials_GitHubApp(t *testing.T) {
+	// In App mode VcsToken is empty; git-over-HTTPS auth must use the "x-access-token"
+	// username and a fresh installation token as the password.
+	c := &Client{
+		cfg:            config.ServerConfig{GithubAppID: 1, GithubInstallationID: 2, GithubPrivateKey: "stub-key"},
+		appTokenSource: stubTokenSource{token: "ghs_installation_token_xyz"},
+	}
+
+	username, password, err := c.GitCredentials(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "x-access-token", username)
+	assert.Equal(t, "ghs_installation_token_xyz", password)
+}
+
+func TestClient_GitCredentials_GitHubApp_TokenFetchError(t *testing.T) {
+	// Token() failure (e.g. expired private key, network failure during JWT exchange)
+	// must propagate rather than silently return empty credentials.
+	c := &Client{
+		cfg:            config.ServerConfig{GithubAppID: 1, GithubInstallationID: 2},
+		appTokenSource: stubTokenSource{err: fmt.Errorf("upstream JWT exchange failed")},
+	}
+
+	_, _, err := c.GitCredentials(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "installation token")
+}
+
+func TestClient_GitCredentials_PAT(t *testing.T) {
+	// In PAT mode there is no token source; credentials come from the static VcsToken
+	// and the client's configured username.
+	c := &Client{
+		cfg:      config.ServerConfig{VcsToken: "ghp_static_pat"},
+		username: "kubechecks-bot",
+	}
+
+	username, password, err := c.GitCredentials(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "kubechecks-bot", username)
+	assert.Equal(t, "ghp_static_pat", password)
+}
+
 func TestClient_VerifyHook(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/vcs/gitlab_client/client.go
+++ b/pkg/vcs/gitlab_client/client.go
@@ -108,6 +108,11 @@ func (c *Client) GetAuthHeaders(_ context.Context) (map[string]string, error) {
 	}, nil
 }
 
+// GitCredentials returns HTTP basic-auth credentials for git-over-HTTPS operations.
+func (c *Client) GitCredentials(_ context.Context) (string, string, error) {
+	return c.username, c.cfg.VcsToken, nil
+}
+
 // VerifyHook returns an err if the webhook isn't valid
 func (c *Client) VerifyHook(r *http.Request, secret string) ([]byte, error) {
 	// If we have a secret, and the secret doesn't match, return an error

--- a/pkg/vcs/types.go
+++ b/pkg/vcs/types.go
@@ -47,6 +47,11 @@ type Client interface {
 	// For GitHub App auth, this fetches a fresh installation token, so the call may
 	// perform a network request and must be passed a context.
 	GetAuthHeaders(ctx context.Context) (map[string]string, error)
+	// GitCredentials returns HTTP basic-auth credentials (username, password) for
+	// git-over-HTTPS operations such as cloning policy and schema repositories. As with
+	// GetAuthHeaders, the password may be a short-lived token resolved per call, so this
+	// may perform a network request and must be passed a context.
+	GitCredentials(ctx context.Context) (username, password string, err error)
 
 	// PostReviewSuggestions posts a PR review with inline code suggestions.
 	// Each suggestion targets a specific file+line in the PR diff.


### PR DESCRIPTION
<!--
Thanks for your contribution! ⚡

- Some repos override this default — check before filling out.
- See the repo's CONTRIBUTING.md for project-specific requirements.
- Keep it focused on the "why" — your diff already covers the "what".
-->

## Summary

Support short-lived tokens (github app auth) for cloning repositories.

## Test plan

Ran it on my local cluster, worked for me.

## Notes for reviewers

<!-- Optional. Risk areas, follow-ups, related Slack/Jira/Linear threads. -->

<!-- Closes # -->
