### PR TITLE
fix(events): log check-result errors at Error level with caller info

### DIFF
--- a/pkg/events/runner.go
+++ b/pkg/events/runner.go
@@ -87,7 +87,7 @@ func (r *Runner) Run(ctx context.Context, desc string, fn checkFunction, worstSt
 			return
 		}
 
-		logger.Info().Str("result", result.State.BareString()).Msg("check result")
+		logger.Info().Caller().Str("result", result.State.BareString()).Msg("check result")
 		addToAppMessage(result)
 	}()
 }

--- a/pkg/events/runner.go
+++ b/pkg/events/runner.go
@@ -79,18 +79,15 @@ func (r *Runner) Run(ctx context.Context, desc string, fn checkFunction, worstSt
 
 		logger.Info().Msgf("running check")
 		result, err := fn(ctx, r.Request)
-		logger.Info().
-			Err(err).
-			Str("result", result.State.BareString()).
-			Msg("check result")
-
 		if err != nil {
+			logger.Error().Caller().Err(err).Str("result", result.State.BareString()).Msg("check result")
 			telemetry.SetError(span, err, desc)
 			result = msg.Result{State: pkg.StateError, Summary: desc, Details: fmt.Sprintf(errorCommentFormat, desc, err)}
 			addToAppMessage(result)
 			return
 		}
 
+		logger.Info().Str("result", result.State.BareString()).Msg("check result")
 		addToAppMessage(result)
 	}()
 }


### PR DESCRIPTION
## Summary
- The "check result" log line in `Runner.Run` logged errors via `Info().Err(err)...` with no `.Caller()`, so failed checks (e.g. "generating diff for app") showed up in logs with no file:line — unlike every other error path in the check-execution flow (`worker.go`), which consistently chains `.Caller()`.
- Now logs at `Error()` level with `.Caller()` when a check returns an error, and keeps the success path at `Info()`.

Found while investigating why an MR's "generating diff for app" check failure (`error getting cached app managed resources: EOF`, caused by an unrelated ArgoCD Redis HA outage) showed up in logs without a source location, while a near-identical error logged elsewhere in the same request did include one.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/events/...`