### PR TITLE
fix(appdir): include multi-source apps when any source matches the branch

### DIFF
--- a/pkg/appdir/app_directory.go
+++ b/pkg/appdir/app_directory.go
@@ -116,22 +116,23 @@ func getSourcePath(app v1alpha1.Application) string {
 }
 
 func shouldInclude(app v1alpha1.Application, targetBranch string) bool {
-	targetRevision := getTargetRevision(app)
-	if targetRevision == "" {
-		return true
-	}
-
-	if targetRevision == targetBranch {
-		return true
-	}
-
-	if targetRevision == "HEAD" {
-		if targetBranch == "main" {
+	// Consider every source: a multi-source Application whose values live in a
+	// git source (targetRevision=<branch>) must be included even when the first
+	// source is a versioned Helm chart (targetRevision=<chart version>).
+	// getTargetRevision(app) only reads app.Spec.GetSource() == Sources[0], so
+	// "chart-first" multi-source apps were incorrectly excluded from PR checks.
+	for _, source := range getSources(app) {
+		targetRevision := source.TargetRevision
+		if targetRevision == "" {
 			return true
 		}
-
-		if targetBranch == "master" {
+		if targetRevision == targetBranch {
 			return true
+		}
+		if targetRevision == "HEAD" {
+			if targetBranch == "main" || targetBranch == "master" {
+				return true
+			}
 		}
 	}
 


### PR DESCRIPTION
### Problem

`shouldInclude` (pkg/appdir/app_directory.go) drops multi-source Applications whose **first** source is a versioned Helm chart.

`getTargetRevision(app)` returns `app.Spec.GetSource().TargetRevision`, which for a multi-source app is `Sources[0]`. A common ArgoCD multi-source layout is:

- `source[0]`: an OCI/Helm **chart** with `targetRevision: <chart version>` (e.g. `0.5.13`) and `helm.valueFiles: ["$values/…"]`
- `source[1]`: a **git ref** source (`ref: values`, `targetRevision: <branch>`) providing the values

When a PR changes the values file in the git repo, the affected app is correctly matched by the change list, but then excluded: `shouldInclude` compares the chart's version (`0.5.13`) against the PR's target branch (`main`) and returns `false`. Result: `No affected apps or appsets, skipping`.

### Fix

Iterate all sources; include the app if **any** source's `targetRevision` matches the branch (or is empty / `HEAD`). This lets chart-first multi-source apps be checked when their git values source targets the PR branch. Single-source behavior is unchanged.

Verified against a live ArgoCD instance where a `.argocd/values.yaml` PR now correctly produces a diff comment (previously "No changes").