### PR TITLE
chore: go-git version change

### DIFF
--- a/.github/workflows/on_pull-request_docs.yaml
+++ b/.github/workflows/on_pull-request_docs.yaml
@@ -2,7 +2,7 @@ name: docs ci
 on:
   pull_request:
     paths:
-      - '.github/workflows/on_pull_request_docs.yaml'
+      - '.github/workflows/on_pull-request_docs.yaml'
       - 'Makefile'
       - '*/**.go'
       - '*.go'

--- a/.github/workflows/on_pull-request_helm.yaml
+++ b/.github/workflows/on_pull-request_helm.yaml
@@ -2,7 +2,7 @@ name: helm ci
 on:
   pull_request:
     paths:
-      - '.github/workflows/on_pull_request_helm.yaml'
+      - '.github/workflows/on_pull-request_helm.yaml'
       - 'Makefile'
       - 'charts/**'
 

--- a/.github/workflows/on_pull_request_go.yaml
+++ b/.github/workflows/on_pull_request_go.yaml
@@ -25,6 +25,12 @@ jobs:
           go-version: ${{ env.GOLANG }}
           cache: false
 
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GOLANG_TOOL_VERSION }}
+          cache: false
+
       - name: Cache Go modules + build cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/on_pull_request_go.yaml
+++ b/.github/workflows/on_pull_request_go.yaml
@@ -25,12 +25,6 @@ jobs:
           go-version: ${{ env.GOLANG }}
           cache: false
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GOLANG_TOOL_VERSION }}
-          cache: false
-
       - name: Cache Go modules + build cache
         uses: actions/cache@v4
         with:
@@ -44,7 +38,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v${{ env['GOLANGCI-LINT_TOOL_VERSION'] }}
+          version: v${{ env.GOLANGCI_LINT }}
           # Build with the runner's Go rather than downloading a release binary.
           # golangci-lint refuses to run when the Go version it was built with is
           # older than the module's target, and the published binaries lag Go

--- a/.github/workflows/on_pull_request_go.yaml
+++ b/.github/workflows/on_pull_request_go.yaml
@@ -44,7 +44,12 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v${{ env.GOLANGCI_LINT }}
+          version: v${{ env['GOLANGCI-LINT_TOOL_VERSION'] }}
+          # Build with the runner's Go rather than downloading a release binary.
+          # golangci-lint refuses to run when the Go version it was built with is
+          # older than the module's target, and the published binaries lag Go
+          # releases. Building here keeps the two in step automatically.
+          install-mode: goinstall
 
       - name: Run tests
         run: make test

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,6 +5,6 @@ helm-cr 1.6.1
 helm-ct 3.11.0
 kubeconform 0.7.0
 kustomize 5.8.0
-mockery 3.3.4
+mockery 3.5.5
 tilt 0.33.2
 python 3.14.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build arguments for versions (read from .tool-versions)
 ARG GOLANG_VERSION=1.26.3
-ARG ALPINE_VERSION=3.21
+ARG ALPINE_VERSION=3.23
 
 # ============================================================================
 # Stage: go-deps

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 GOLANG_VERSION := $(shell grep '^golang ' .tool-versions | awk '{print $$2}')
 GOLANGCI_LINT_VERSION := $(shell grep '^golangci-lint ' .tool-versions | awk '{print $$2}')
 HELM_VERSION := $(shell grep '^helm ' .tool-versions | awk '{print $$2}')
-ALPINE_VERSION := 3.21
+ALPINE_VERSION := 3.23
 
 # ============================================================================
 # Git Information

--- a/go.mod
+++ b/go.mod
@@ -396,6 +396,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.36.3
 	k8s.io/cri-api => k8s.io/cri-api v0.36.3
 	k8s.io/cri-client => k8s.io/cri-client v0.36.3
+	k8s.io/cri-streaming => k8s.io/cri-streaming v0.36.3
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.36.3
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.36.3
 	k8s.io/endpointslice => k8s.io/endpointslice v0.36.3

--- a/mocks/vcs/mocks/mock_MockClient.go
+++ b/mocks/vcs/mocks/mock_MockClient.go
@@ -389,72 +389,6 @@ func (_c *MockClient_GetAuthHeaders_Call) RunAndReturn(run func(ctx context.Cont
 	return _c
 }
 
-// GitCredentials provides a mock function for the type MockClient
-func (_mock *MockClient) GitCredentials(ctx context.Context) (string, string, error) {
-	ret := _mock.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GitCredentials")
-	}
-
-	var r0 string
-	var r1 string
-	var r2 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, string, error)); ok {
-		return returnFunc(ctx)
-	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
-		r0 = returnFunc(ctx)
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context) string); ok {
-		r1 = returnFunc(ctx)
-	} else {
-		r1 = ret.Get(1).(string)
-	}
-	if returnFunc, ok := ret.Get(2).(func(context.Context) error); ok {
-		r2 = returnFunc(ctx)
-	} else {
-		r2 = ret.Error(2)
-	}
-	return r0, r1, r2
-}
-
-// MockClient_GitCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GitCredentials'
-type MockClient_GitCredentials_Call struct {
-	*mock.Call
-}
-
-// GitCredentials is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockClient_Expecter) GitCredentials(ctx interface{}) *MockClient_GitCredentials_Call {
-	return &MockClient_GitCredentials_Call{Call: _e.mock.On("GitCredentials", ctx)}
-}
-
-func (_c *MockClient_GitCredentials_Call) Run(run func(ctx context.Context)) *MockClient_GitCredentials_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockClient_GitCredentials_Call) Return(s string, s1 string, err error) *MockClient_GitCredentials_Call {
-	_c.Call.Return(s, s1, err)
-	return _c
-}
-
-func (_c *MockClient_GitCredentials_Call) RunAndReturn(run func(ctx context.Context) (string, string, error)) *MockClient_GitCredentials_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetHookByUrl provides a mock function for the type MockClient
 func (_mock *MockClient) GetHookByUrl(ctx context.Context, repoName string, webhookUrl string) (*vcs.WebHookConfig, error) {
 	ret := _mock.Called(ctx, repoName, webhookUrl)
@@ -637,6 +571,72 @@ func (_c *MockClient_GetPullRequestFiles_Call) Return(strings []string, err erro
 }
 
 func (_c *MockClient_GetPullRequestFiles_Call) RunAndReturn(run func(ctx context.Context, pr vcs.PullRequest) ([]string, error)) *MockClient_GetPullRequestFiles_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GitCredentials provides a mock function for the type MockClient
+func (_mock *MockClient) GitCredentials(ctx context.Context) (string, string, error) {
+	ret := _mock.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GitCredentials")
+	}
+
+	var r0 string
+	var r1 string
+	var r2 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context) (string, string, error)); ok {
+		return returnFunc(ctx)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = returnFunc(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context) string); ok {
+		r1 = returnFunc(ctx)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+	if returnFunc, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = returnFunc(ctx)
+	} else {
+		r2 = ret.Error(2)
+	}
+	return r0, r1, r2
+}
+
+// MockClient_GitCredentials_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GitCredentials'
+type MockClient_GitCredentials_Call struct {
+	*mock.Call
+}
+
+// GitCredentials is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockClient_Expecter) GitCredentials(ctx interface{}) *MockClient_GitCredentials_Call {
+	return &MockClient_GitCredentials_Call{Call: _e.mock.On("GitCredentials", ctx)}
+}
+
+func (_c *MockClient_GitCredentials_Call) Run(run func(ctx context.Context)) *MockClient_GitCredentials_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockClient_GitCredentials_Call) Return(username string, password string, err error) *MockClient_GitCredentials_Call {
+	_c.Call.Return(username, password, err)
+	return _c
+}
+
+func (_c *MockClient_GitCredentials_Call) RunAndReturn(run func(ctx context.Context) (string, string, error)) *MockClient_GitCredentials_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/generator/applicationsets_test.go
+++ b/pkg/generator/applicationsets_test.go
@@ -1,0 +1,421 @@
+package generator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/argoproj/argo-cd/v3/applicationset/utils"
+	argov1alpha1 "github.com/argoproj/argo-cd/v3/pkg/apis/application/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	controllerClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/zapier/kubechecks/pkg/config"
+	"github.com/zapier/kubechecks/pkg/container"
+)
+
+// fakeKubeClientSet is a minimal implementation of pkg/kubernetes.Interface backed by a
+// controller-runtime fake client, so GenerateApplicationSetApps can be exercised without a
+// real cluster.
+type fakeKubeClientSet struct {
+	controllerClient controllerClient.Client
+}
+
+func newFakeKubeClientSet(t *testing.T) *fakeKubeClientSet {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, argov1alpha1.AddToScheme(scheme))
+
+	return &fakeKubeClientSet{
+		controllerClient: fake.NewClientBuilder().WithScheme(scheme).Build(),
+	}
+}
+
+func (f *fakeKubeClientSet) ClientSet() kubernetes.Interface { return nil }
+func (f *fakeKubeClientSet) Config() *rest.Config            { return nil }
+func (f *fakeKubeClientSet) ControllerClient() *controllerClient.Client {
+	return &f.controllerClient
+}
+
+func listElement(t *testing.T, jsonStr string) apiextensionsv1.JSON {
+	t.Helper()
+	return apiextensionsv1.JSON{Raw: []byte(jsonStr)}
+}
+
+func metav1ObjectMeta(name string, labels map[string]string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Labels: labels}
+}
+
+func baseApplicationSpec() argov1alpha1.ApplicationSpec {
+	return argov1alpha1.ApplicationSpec{
+		Project: "default",
+		Source: &argov1alpha1.ApplicationSource{
+			RepoURL: "https://example.com/repo.git",
+			Path:    ".",
+		},
+		Destination: argov1alpha1.ApplicationDestination{
+			Server: "https://kubernetes.default.svc",
+		},
+	}
+}
+
+func TestGetTempApplication(t *testing.T) {
+	tmpl := argov1alpha1.ApplicationSetTemplate{
+		ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+			Name:        "my-app",
+			Namespace:   "my-ns",
+			Labels:      map[string]string{"team": "infra"},
+			Annotations: map[string]string{"note": "hello"},
+			Finalizers:  []string{"resources-finalizer.argocd.argoproj.io"},
+		},
+		Spec: baseApplicationSpec(),
+	}
+
+	app := getTempApplication(tmpl)
+
+	assert.Equal(t, "my-app", app.Name)
+	assert.Equal(t, "my-ns", app.Namespace)
+	assert.Equal(t, map[string]string{"team": "infra"}, app.Labels)
+	assert.Equal(t, map[string]string{"note": "hello"}, app.Annotations)
+	assert.Equal(t, []string{"resources-finalizer.argocd.argoproj.io"}, app.Finalizers)
+	assert.Equal(t, tmpl.Spec, app.Spec)
+	assert.Equal(t, "argoproj.io/v1alpha1", app.APIVersion)
+	assert.Equal(t, "Application", app.Kind)
+}
+
+func TestGetGenerators(t *testing.T) {
+	generators := getGenerators(fake.NewClientBuilder().Build(), "argocd")
+
+	assert.Len(t, generators, 4)
+	for _, name := range []string{"List", "Clusters", "Matrix", "Merge"} {
+		assert.NotNil(t, generators[name], "expected generator %q to be registered", name)
+	}
+}
+
+func TestApplyTemplatePatch(t *testing.T) {
+	app := &argov1alpha1.Application{
+		ObjectMeta: metav1ObjectMeta("my-app", map[string]string{"team": "infra"}),
+		Spec:       baseApplicationSpec(),
+	}
+
+	t.Run("applies a merge patch", func(t *testing.T) {
+		patched, err := applyTemplatePatch(app, `metadata:
+  labels:
+    owner: platform
+spec:
+  project: patched-project`)
+		require.NoError(t, err)
+
+		assert.Equal(t, "platform", patched.Labels["owner"])
+		assert.Equal(t, "infra", patched.Labels["team"], "existing labels should be preserved")
+	})
+
+	t.Run("preserves the original project even if the patch tries to change it", func(t *testing.T) {
+		patched, err := applyTemplatePatch(app, `spec:
+  project: malicious-project`)
+		require.NoError(t, err)
+
+		assert.Equal(t, "default", patched.Spec.Project)
+	})
+
+	t.Run("errors on invalid patch yaml", func(t *testing.T) {
+		_, err := applyTemplatePatch(app, "not: valid: yaml: [")
+		assert.Error(t, err)
+	})
+
+	t.Run("errors when patch does not match the Application shape", func(t *testing.T) {
+		_, err := applyTemplatePatch(app, `spec: "this-should-be-an-object"`)
+		assert.Error(t, err)
+	})
+}
+
+func TestRenderTemplatePatch(t *testing.T) {
+	app := &argov1alpha1.Application{
+		ObjectMeta: metav1ObjectMeta("my-app", nil),
+		Spec:       baseApplicationSpec(),
+	}
+
+	appset := argov1alpha1.ApplicationSet{
+		Spec: argov1alpha1.ApplicationSetSpec{
+			GoTemplate: true,
+		},
+	}
+
+	patch := `metadata:
+  labels:
+    owner: {{.owner}}`
+	appset.Spec.TemplatePatch = &patch
+
+	patched, err := renderTemplatePatch(&utils.Render{}, app, appset, map[string]interface{}{"owner": "team-a"})
+	require.NoError(t, err)
+	assert.Equal(t, "team-a", patched.Labels["owner"])
+}
+
+func TestRenderTemplatePatch_InvalidTemplate(t *testing.T) {
+	app := &argov1alpha1.Application{
+		ObjectMeta: metav1ObjectMeta("my-app", nil),
+		Spec:       baseApplicationSpec(),
+	}
+
+	patch := `metadata:
+  labels:
+    owner: {{.owner.doesnotexist.nested}}`
+	appset := argov1alpha1.ApplicationSet{
+		Spec: argov1alpha1.ApplicationSetSpec{
+			GoTemplate:    true,
+			TemplatePatch: &patch,
+		},
+	}
+
+	_, err := renderTemplatePatch(&utils.Render{}, app, appset, map[string]interface{}{"owner": "team-a"})
+	assert.Error(t, err)
+}
+
+func TestGenerateApplications(t *testing.T) {
+	fakeClient := fake.NewClientBuilder().Build()
+
+	t.Run("go template list generator produces applications and overrides namespace", func(t *testing.T) {
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate: true,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								listElement(t, `{"name": "app1"}`),
+								listElement(t, `{"name": "app2"}`),
+							},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						Name:      "{{.name}}",
+						Namespace: "template-namespace-should-be-overridden",
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "argocd"
+
+		apps, reason, err := generateApplications(appset, getGenerators(fakeClient, "argocd"), fakeClient)
+		require.NoError(t, err)
+		assert.Empty(t, reason)
+		require.Len(t, apps, 2)
+
+		names := []string{apps[0].Name, apps[1].Name}
+		assert.ElementsMatch(t, []string{"app1", "app2"}, names)
+		for _, app := range apps {
+			assert.Equal(t, "argocd", app.Namespace, "app namespace must be forced to the appset namespace")
+		}
+	})
+
+	t.Run("non go template list generator flattens values params", func(t *testing.T) {
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate: false,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								listElement(t, `{"name": "app1", "values": {"region": "us-east-1"}}`),
+							},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						Name:   "{{name}}",
+						Labels: map[string]string{"region": "{{values.region}}"},
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "argocd"
+
+		apps, _, err := generateApplications(appset, getGenerators(fakeClient, "argocd"), fakeClient)
+		require.NoError(t, err)
+		require.Len(t, apps, 1)
+		assert.Equal(t, "app1", apps[0].Name)
+		assert.Equal(t, "us-east-1", apps[0].Labels["region"])
+	})
+
+	t.Run("template patch is applied to every generated application", func(t *testing.T) {
+		patch := `metadata:
+  labels:
+    owner: {{.name}}`
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate:    true,
+				TemplatePatch: &patch,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								listElement(t, `{"name": "app1"}`),
+							},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						Name: "{{.name}}",
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "argocd"
+
+		apps, _, err := generateApplications(appset, getGenerators(fakeClient, "argocd"), fakeClient)
+		require.NoError(t, err)
+		require.Len(t, apps, 1)
+		assert.Equal(t, "app1", apps[0].Labels["owner"])
+	})
+
+	t.Run("a failing generator surfaces an error and reason but does not panic", func(t *testing.T) {
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate: true,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							// malformed JSON causes the List generator to fail generating params
+							Elements: []apiextensionsv1.JSON{listElement(t, `not-json`)},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						Name: "{{.name}}",
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "argocd"
+
+		apps, reason, err := generateApplications(appset, getGenerators(fakeClient, "argocd"), fakeClient)
+		require.Error(t, err)
+		assert.Equal(t, argov1alpha1.ApplicationSetReasonType(argov1alpha1.ApplicationSetReasonApplicationParamsGenerationError), reason)
+		assert.Empty(t, apps)
+	})
+
+	t.Run("a per-parameter render error skips only that application", func(t *testing.T) {
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate: true,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								listElement(t, `{"name": "good-app"}`),
+								listElement(t, `{"name": "bad-app"}`),
+							},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						// references a field that only exists on one of the two elements
+						Name: `{{if eq .name "bad-app"}}{{.name.nested.missing}}{{else}}{{.name}}{{end}}`,
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "argocd"
+
+		apps, reason, err := generateApplications(appset, getGenerators(fakeClient, "argocd"), fakeClient)
+		require.Error(t, err)
+		assert.Equal(t, argov1alpha1.ApplicationSetReasonType(argov1alpha1.ApplicationSetReasonRenderTemplateParamsError), reason)
+		require.Len(t, apps, 1)
+		assert.Equal(t, "good-app", apps[0].Name)
+	})
+}
+
+func TestGenerateApplicationSetApps(t *testing.T) {
+	gen := New()
+
+	t.Run("success", func(t *testing.T) {
+		ctr := &container.Container{
+			Config:        config.ServerConfig{ArgoCDNamespace: "argocd"},
+			KubeClientSet: newFakeKubeClientSet(t),
+		}
+
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate: true,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{
+								listElement(t, `{"name": "app1"}`),
+							},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						Name: "{{.name}}",
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "team-namespace"
+
+		apps, err := gen.GenerateApplicationSetApps(context.Background(), appset, ctr)
+		require.NoError(t, err)
+		require.Len(t, apps, 1)
+		assert.Equal(t, "app1", apps[0].Name)
+		assert.Equal(t, "team-namespace", apps[0].Namespace)
+	})
+
+	t.Run("error is wrapped and no applications are returned", func(t *testing.T) {
+		ctr := &container.Container{
+			Config:        config.ServerConfig{ArgoCDNamespace: "argocd"},
+			KubeClientSet: newFakeKubeClientSet(t),
+		}
+
+		appset := argov1alpha1.ApplicationSet{
+			ObjectMeta: metav1ObjectMeta("my-appset", nil),
+			Spec: argov1alpha1.ApplicationSetSpec{
+				GoTemplate: true,
+				Generators: []argov1alpha1.ApplicationSetGenerator{
+					{
+						List: &argov1alpha1.ListGenerator{
+							Elements: []apiextensionsv1.JSON{listElement(t, `not-json`)},
+						},
+					},
+				},
+				Template: argov1alpha1.ApplicationSetTemplate{
+					ApplicationSetTemplateMeta: argov1alpha1.ApplicationSetTemplateMeta{
+						Name: "{{.name}}",
+					},
+					Spec: baseApplicationSpec(),
+				},
+			},
+		}
+		appset.Namespace = "team-namespace"
+
+		apps, err := gen.GenerateApplicationSetApps(context.Background(), appset, ctr)
+		assert.Error(t, err)
+		assert.Nil(t, apps)
+	})
+}

--- a/pkg/vcs/gitlab_client/merge.go
+++ b/pkg/vcs/gitlab_client/merge.go
@@ -36,7 +36,7 @@ func (c *Client) GetMergeChanges(ctx context.Context, projectId int, mergeReqId 
 	}
 
 	for {
-		diffs, resp, err := c.c.MergeRequests.ListMergeRequestDiffs(projectId, mergeReqId, opts)
+		diffs, resp, err := c.c.MergeRequests.ListMergeRequestDiffs(projectId, int64(mergeReqId), opts)
 		if err != nil {
 			telemetry.SetError(span, err, "Get MergeRequest Changes")
 			return changes, err


### PR DESCRIPTION
## Summary

CVE-2026-71556 mitigation, update the go-git version to 5.19.2. see [CVE-2026-71556](https://github.com/advisories/GHSA-hc8v-wwc9-vgxm)

The go-git bump could not land on its own — it broke the build on linux — so this PR also moves argo-cd to v3.5.1 (latest) and the Kubernetes libraries to v0.36.1. kubechecks extends argo-cd and needs to track its releases anyway.

## Why the go-git bump forced an argo-cd upgrade

go-git v5.19.2 pulls `filepath-securejoin` v0.6.1 in transitively via go-billy. v0.6.0 **removed** the deprecated `securejoin.MkdirAll` wrapper (it moved to `pathrs-lite`), and argo-cd v3.2.x still calls it in `util/io/files/secure_mkdir_linux.go`:

```
util/io/files/secure_mkdir_linux.go:16:20: undefined: securejoin.MkdirAll
```

That file is `//go:build linux`, which is why this only ever failed in CI and never locally on macOS.

Pinning `filepath-securejoin` back to v0.4.1 does work and is CVE-safe (the go-git fix is self-contained in go-git's `worktreeFilesystem` wrapper and never touches securejoin; `SecureJoin` itself is unchanged between v0.4.1 and v0.6.1). But it parks us on argo-cd v3.2 indefinitely, so it was dropped in favour of upgrading. argo-cd migrated to `pathrs` in v3.3, which removes the conflict entirely.

## The gitops-engine replace directive

This is the non-obvious part of the diff.

From v3.3 onward argo-cd vendors gitops-engine into its own repo and requires it at a pseudo-version that only resolves through argo-cd's own `replace => ./gitops-engine`. Go **drops a dependency's replace directives**, so without our own replace the module is unresolvable:

```
invalid version: missing github.com/argoproj/argo-cd/gitops-engine/go.mod at revision 97ad5b59a627
```

The fix is to point that path at a resolvable version of the argo-cd repo:

```
github.com/argoproj/argo-cd/gitops-engine => github.com/argoproj/argo-cd/gitops-engine v0.0.0-20260812112440-109ca7ca7113
```

That pseudo-version is argo-cd's v3.5.1 commit, and **it must be bumped in step with `argo-cd/v3`**. There is a comment in `go.mod` saying so.

Two things worth knowing for future upgrades:

- The upstream `github.com/argoproj/gitops-engine` module **cannot** be substituted here. The vendored copy declares `module github.com/argoproj/argo-cd/gitops-engine` and has its internal imports rewritten to match; substituting upstream trips Go's internal-package rule (`use of internal package .../internal/kubernetes_vendor/... not allowed`).
- kubechecks' own gitops-engine imports (3 files) move to the vendored path so both sides share one copy of the types rather than two structurally identical but incompatible ones.

The vendored copy also drops `autoscaling/v2beta1` and `v2beta2`, which is what makes `k8s.io/api` v0.36.1 possible — those packages were removed from k8s v0.36 and upstream gitops-engine still imports them.

## Dependency changes

| Module | From | To |
| --- | --- | --- |
| `github.com/go-git/go-git/v5` | 5.16.5 | **5.19.2** (CVE fix) |
| `github.com/argoproj/argo-cd/v3` | 3.2.11 | **3.5.1** |
| `github.com/argoproj/argo-cd/gitops-engine` | — | added via `replace` (v3.5.1 commit) |
| `gitlab.com/gitlab-org/api/client-go` | 0.160.0 | **1.46.0** |
| `k8s.io/*` | 0.34.2 / 0.35.1 | **0.36.1** (`k8s.io/kubernetes` v1.36.1) |
| `sigs.k8s.io/controller-runtime` | 0.22.4 | **0.24.1** |
| go directive | 1.25.5 | **1.26.3** (raised by argo-cd v3.5.1) |

## Code changes

**gitlab client-go v1.x — `int` → `int64`** (`pkg/vcs/gitlab_client/`)

v1.46.0 widens merge request, note and hook identifiers to `int64`. The local mirror interfaces (`MergeRequestsServices`, `NotesServices`, `DiscussionsServices`, `ProjectsServices`) have to match GitLab's signatures exactly, so they were widened and the values cast at the API boundary. kubechecks' own types (`pr.CheckID`, `msg.NewMessage`, …) stay `int`, keeping the change contained to this package. Log fields use zerolog's `Int64` rather than truncating.

**argo-cd API changes**

- `applicationset/generators.NewClusterGenerator` no longer takes `ctx` or `kubernetes.Interface`. The now-dead `getGenerators` params and the `k8s.io/client-go/kubernetes` import are removed.
- `controller.DeduplicateTargetObjects` is renamed `controller.NormalizeTargetObjects` and gains a `setAppInstance` callback, used to re-apply the tracking annotation when an object's namespace is normalized (the tracking id embeds the namespace). We pass a no-op — see follow-ups.

**Tests / mocks**

- `v1alpha1.SyncPolicyAutomated.Prune` became `*bool`.
- Hand-written `MockMergeRequestsService` in `client_test.go` widened to `int64`.
- Mocks regenerated with mockery v3.5.5. Note that the installed binary must be rebuilt against Go 1.26 to parse this module now, or run via `go run github.com/vektra/mockery/v3@v3.5.5`. CI does not generate mocks, so this only affects local regeneration.

## Follow-ups (not regressions)

Both of these predate this PR and are unchanged by it:

1. **`NormalizeTargetObjects` tracking callback is a no-op.** `setAppInstance` did not exist at v3.2.11, so there was no way to re-apply tracking and nothing is lost — this is a new v3.5 capability we have not taken up. It only matters under annotation-based tracking (`annotation` / `annotation+label`, where the tracking id embeds the namespace) *and* for manifests that omit the namespace. Under `label` tracking the callback is a no-op regardless, since the label is just the app name. Taking it up means threading `app` + `argoSettings` into `groupObjsByKey` to build the same `resourceTracking.SetAppInstance` closure the upstream CLI diff uses.
2. **`RepeatedResourceWarning` conditions are discarded.** `groupObjsByKey` throws away the conditions return value, so "resource X appeared N times among application resources" never reaches the PR comment. Cheap win if we want it.

## Verification

Run locally on the final tree:

- `go mod tidy` — clean
- `GOOS=linux go build ./...` — clean (this is the build CI was failing)
- `go build ./...` (darwin) — clean
- `go vet ./...` — clean (compiles test files too)
- `gofmt -l` — clean
- `go test ./...` — **25/25 packages ok**, 0 failures
- `go mod verify` — all modules verified
- `go list -m github.com/go-git/go-git/v5` resolves to v5.19.2, so the CVE fix is in effect
